### PR TITLE
fix(jwt,auth): harden JWT algorithms and path matching

### DIFF
--- a/docs/middlewares/jwt.md
+++ b/docs/middlewares/jwt.md
@@ -18,7 +18,7 @@ middlewares:
     paths: ["/*"]
     rule:
       secret: "your-secret-key-here"
-      algo: "HS256"
+      algorithms: ["HS256"]
 ```
 
 ## Authentication Methods
@@ -31,7 +31,7 @@ Use a shared secret key for HMAC algorithms like HS256, HS384, or HS512.
 ```yaml
 rule:
   secret: "MgsEUFgn9xiMym9Lo9rcRUa3wJbQBo..."
-  algo: "HS256"
+  algorithms: ["HS256"]
 ```
 
 ###  Public Key (RSA/ECDSA)
@@ -43,7 +43,7 @@ rule:
     -----BEGIN PUBLIC KEY-----
     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
     -----END PUBLIC KEY-----
-  algo: "RS256"
+  algorithms: ["RS256"]
 ```
 
 You can also provide:
@@ -56,7 +56,7 @@ Dynamically fetch public keys from a JSON Web Key Set endpoint.
 ```yaml
 rule:
   jwksUrl: "https://your-auth-provider.com/.well-known/jwks.json"
-  algo: "RS256"
+  algorithms: ["RS256"]
 ```
 
 ### JWKS File
@@ -73,15 +73,23 @@ rule:
 
 ### Core Settings
 
-| Option      | Type   | Required | Description                                    |
-|-------------|--------|----------|------------------------------------------------|
-| `secret`    | string | *        | Shared secret for HMAC algorithms              |
-| `publicKey` | string | *        | PEM public key (content, file path, or base64) |
-| `jwksUrl`   | string | *        | URL to fetch JWKS dynamically                  |
-| `jwksFile`  | string | *        | JWKS file path or content                      |
-| `algo`      | string | No       | Expected JWT algorithm (highly recommended)    |
+| Option       | Type     | Required | Description                                                    |
+|--------------|----------|----------|---------------------------------------------------------------|
+| `secret`     | string   | *        | Shared secret for HMAC algorithms                             |
+| `publicKey`  | string   | *        | PEM public key (content, file path, or base64)                |
+| `jwksUrl`    | string   | *        | URL to fetch JWKS dynamically                                 |
+| `jwksFile`   | string   | *        | JWKS file path or content                                     |
+| `algorithms` | []string | No       | Accepted JWT signing algorithms, e.g. `["RS256", "ES256"]`    |
+| `algo`       | string   | No       | **Deprecated** — use `algorithms`. Single accepted algorithm. |
 
 **\* One of these four options is required**
+
+> **Algorithm selection.** When `algorithms` (and the deprecated `algo`) are
+> omitted, the gateway accepts a safe set scoped to the configured key type: the
+> HMAC family (`HS256/384/512`) for a shared `secret`, and asymmetric algorithms
+> (`RS*`, `ES*`, `PS*`) for `publicKey` / `jwksUrl` / `jwksFile`. An HMAC token is
+> never accepted against an asymmetric key, preventing algorithm-confusion
+> attacks. Set `algorithms` to pin an explicit list.
 
 ### Token Validation
 
@@ -159,7 +167,7 @@ middlewares:
     paths: ["/api/*"]
     rule:
       secret: "your-256-bit-secret"
-      algo: "HS256"
+      algorithms: ["HS256"]
       issuer: "https://your-auth-service.com"
 ```
 
@@ -174,7 +182,7 @@ middlewares:
       jwksUrl: "https://auth.company.com/.well-known/jwks.json"
       issuer: "https://auth.company.com"
       audience: "api.company.com"
-      algo: "RS256"
+      algorithms: ["RS256"]
       forwardAuthorization: false
       claimsExpression: >
         Equals('email_verified', true) &&
@@ -197,7 +205,7 @@ middlewares:
     paths: ["/tenant/*/api/*"]
     rule:
       publicKey: "/etc/ssl/jwt-public.pem"
-      algo: "RS256"
+      algorithms: ["RS256"]
       claimsExpression: >
         Equals('email_verified', true) &&
         Contains('scopes', 'api:read') &&

--- a/docs/operator-manual/middlware.md
+++ b/docs/operator-manual/middlware.md
@@ -108,7 +108,8 @@ spec:
     jwksUrl: https://auth.example.com/.well-known/jwks.json
     issuer: https://auth.example.com/
     audience: api.example.com
-    algo: RS256
+    algorithms:
+      - RS256
     claimsExpression: >
       Equals('email_verified', true) && !Equals('account_disabled', true)
     forwardHeaders:

--- a/internal/middleware.go
+++ b/internal/middleware.go
@@ -551,6 +551,7 @@ func applyJWTAuthMiddleware(route Route, routeMiddleware Middleware, r *mux.Rout
 		ForwardAuthorization: rule.ForwardAuthorization,
 		RsaKey:               key,
 		Algo:                 rule.Alg,
+		Algorithms:           rule.Algorithms,
 		JwksFile:             jwksFile,
 		Secret:               rule.Secret,
 		JwksUrl:              rule.JwksUrl,

--- a/internal/middlewares/helpers.go
+++ b/internal/middlewares/helpers.go
@@ -226,20 +226,30 @@ func IsPathMatching(urlPath, prefix string, paths []string) (bool, string) {
 	return false, ""
 }
 
-// Helper function to determine if the request path is blocked
+// Helper function to determine if the request path is blocked.
+//
+// Matching is case-insensitive: many upstream servers and frameworks treat URL
+// paths case-insensitively, so a case-sensitive comparison here would let a
+// request like "/Admin" slip past an auth/block rule for "/admin" while still
+// reaching the protected resource. Comparing case-insensitively fails safe.
 func isMatchingPath(requestPath, blockedPath string) bool {
 	// Handle exact match
-	if requestPath == blockedPath {
+	if strings.EqualFold(requestPath, blockedPath) {
 		return true
 	}
 	// Handle wildcard match (e.g., /admin/* should block /admin and any subpath)
 	if strings.HasSuffix(blockedPath, "/*") {
 		basePath := strings.TrimSuffix(blockedPath, "/*")
-		if strings.HasPrefix(requestPath, basePath) {
+		if hasPrefixFold(requestPath, basePath) {
 			return true
 		}
 	}
 	return false
+}
+
+// hasPrefixFold reports whether s starts with prefix, ignoring case.
+func hasPrefixFold(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
 }
 func serveHTMLFile(w http.ResponseWriter, statusCode int, filePath string) {
 	htmlCacheMu.RLock()

--- a/internal/middlewares/jwt_middleware.go
+++ b/internal/middlewares/jwt_middleware.go
@@ -18,9 +18,10 @@ package middlewares
 
 import (
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
 	"net/http"
 	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func (jwtAuth *JwtAuth) AuthMiddleware(next http.Handler) http.Handler {
@@ -52,12 +53,8 @@ func (jwtAuth *JwtAuth) AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if jwtAuth.Algo != "" {
-			jwtAlgo = []string{jwtAuth.Algo}
-		}
-
 		token, err := jwt.Parse(tokenStr, keyFunc,
-			jwt.WithValidMethods(jwtAlgo),
+			jwt.WithValidMethods(jwtAuth.allowedAlgorithms()),
 			jwt.WithAudience(jwtAuth.Audience),
 			jwt.WithIssuer(jwtAuth.Issuer),
 		)
@@ -96,6 +93,43 @@ func (jwtAuth *JwtAuth) AuthMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// hmacAlgorithms are the symmetric signing algorithms accepted for a shared
+// Secret. asymmetricAlgorithms are the algorithms accepted for an RSA/EC public
+// key (JWKS or RSA key); HMAC is deliberately excluded from this set so an
+// attacker cannot forge a token by signing HS256 with the public key as the HMAC
+// secret (the RS/HS algorithm-confusion attack).
+var (
+	hmacAlgorithms       = []string{"HS256", "HS384", "HS512"}
+	asymmetricAlgorithms = []string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}
+)
+
+// allowedAlgorithms returns the JWT signing algorithms accepted for this
+// middleware, derived per-request (never a shared mutable global) and scoped to
+// the configured key type. The key-source precedence mirrors resolveKeyFunc so
+// the accepted algorithms always match the key actually used for verification.
+// An explicit Algorithms list (or the deprecated single Algo) overrides the
+// defaults.
+func (jwtAuth *JwtAuth) allowedAlgorithms() []string {
+	if len(jwtAuth.Algorithms) != 0 {
+		return jwtAuth.Algorithms
+	}
+	if jwtAuth.Algo != "" { // Deprecated: superseded by Algorithms.
+		return []string{jwtAuth.Algo}
+	}
+	switch {
+	case jwtAuth.JwksUrl != "":
+		return asymmetricAlgorithms
+	case jwtAuth.Secret != "":
+		return hmacAlgorithms
+	case jwtAuth.JwksFile != nil && len(jwtAuth.JwksFile.Keys) != 0:
+		return asymmetricAlgorithms
+	case jwtAuth.RsaKey != nil:
+		return asymmetricAlgorithms
+	default:
+		return asymmetricAlgorithms
+	}
 }
 
 // validateHeaders checks if the required headers are present in the request

--- a/internal/middlewares/jwt_security_test.go
+++ b/internal/middlewares/jwt_security_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 Jonas Kaninda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middlewares
+
+import (
+	"crypto/rsa"
+	"slices"
+	"testing"
+)
+
+const (
+	algRS512  = "RS512"
+	algES384  = "ES384"
+	adminPath = "/admin"
+)
+
+func TestAllowedAlgorithms(t *testing.T) {
+	// Asymmetric key sources must never accept HMAC (RS/HS confusion guard).
+	asym := []*JwtAuth{
+		{JwksUrl: "https://issuer.example/jwks"},
+		{RsaKey: &rsa.PublicKey{}},
+		{JwksFile: &Jwks{Keys: []Jwk{{}}}},
+		{}, // no key configured → safe default
+	}
+	for _, j := range asym {
+		got := j.allowedAlgorithms()
+		if slices.Contains(got, "HS256") {
+			t.Fatalf("asymmetric config must not allow HS256, got %v", got)
+		}
+		if !slices.Contains(got, "RS256") {
+			t.Fatalf("asymmetric config should allow RS256, got %v", got)
+		}
+	}
+
+	// A shared secret is an HMAC key → HMAC family only, no asymmetric algs.
+	hs := (&JwtAuth{Secret: "s3cret"}).allowedAlgorithms()
+	if !slices.Contains(hs, "HS256") || slices.Contains(hs, "RS256") {
+		t.Fatalf("secret config should allow only HMAC, got %v", hs)
+	}
+
+	// JWKS URL takes precedence over a stray Secret, mirroring resolveKeyFunc.
+	mixed := (&JwtAuth{JwksUrl: "https://issuer.example/jwks", Secret: "s"}).allowedAlgorithms()
+	if slices.Contains(mixed, "HS256") {
+		t.Fatalf("JWKS URL must win over Secret and exclude HMAC, got %v", mixed)
+	}
+
+	// Explicit (deprecated) Algo overrides the defaults.
+	exact := (&JwtAuth{Secret: "s", Algo: algRS512}).allowedAlgorithms()
+	if len(exact) != 1 || exact[0] != algRS512 {
+		t.Fatalf("explicit Algo should be the only allowed method, got %v", exact)
+	}
+
+	// Explicit Algorithms list is used verbatim and wins over the deprecated Algo.
+	list := (&JwtAuth{Algo: "HS256", Algorithms: []string{algRS512, algES384}}).allowedAlgorithms()
+	if !slices.Equal(list, []string{algRS512, algES384}) {
+		t.Fatalf("Algorithms should take precedence over Algo, got %v", list)
+	}
+}
+
+func TestIsMatchingPathCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		req, rule string
+		want      bool
+	}{
+		{adminPath, adminPath, true},
+		{"/Admin", adminPath, true}, // case bypass must not work
+		{"/ADMIN", adminPath, true},
+		{"/admin/users", "/admin/*", true},
+		{"/Admin/Users", "/admin/*", true}, // case bypass on wildcard
+		{"/public", adminPath, false},
+		{"/administrator", adminPath, false}, // exact rule, not a prefix
+	}
+	for _, tc := range cases {
+		if got := isMatchingPath(tc.req, tc.rule); got != tc.want {
+			t.Fatalf("isMatchingPath(%q, %q) = %v, want %v", tc.req, tc.rule, got, tc.want)
+		}
+	}
+}

--- a/internal/middlewares/types.go
+++ b/internal/middlewares/types.go
@@ -21,9 +21,10 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"golang.org/x/time/rate"
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 // Client stores request count and window expiration for each client.
@@ -81,10 +82,15 @@ type ProxyResponseError struct {
 
 // JwtAuth  stores JWT configuration
 type JwtAuth struct {
-	Path                 string
-	Paths                []string
-	Origins              []string
-	Algo                 string
+	Path    string
+	Paths   []string
+	Origins []string
+	// Algo restricts the accepted JWT signing algorithm.
+	// Deprecated: use Algorithms instead.
+	Algo string
+	// Algorithms is the list of accepted JWT signing algorithms. When empty, a
+	// safe set scoped to the configured key type is used.
+	Algorithms           []string
 	Issuer               string
 	Audience             string
 	Secret               string

--- a/internal/middlewares/var.go
+++ b/internal/middlewares/var.go
@@ -43,5 +43,4 @@ var (
 	TrustedProxyConfig = &config.ProxyConfig{}
 	limiter            *redis_rate.Limiter
 	logger             = logger2.Default()
-	jwtAlgo            = []string{"RS256", "HS256", "ES256"}
 )

--- a/internal/types.go
+++ b/internal/types.go
@@ -129,7 +129,13 @@ type RewriteRegexRuleMiddleware struct {
 //
 // JWTRuleMiddleware contains the authentication details
 type JWTRuleMiddleware struct {
-	Alg                  string            `yaml:"alg,omitempty" json:"alg"`
+	// Alg restricts the accepted JWT signing algorithm.
+	// Deprecated: use Algorithms instead.
+	Alg string `yaml:"alg,omitempty" json:"alg"`
+	// Algorithms is the list of accepted JWT signing algorithms (e.g.
+	// ["RS256", "ES256"]). When empty, a safe set scoped to the configured key
+	// type is used (HMAC for a shared secret, asymmetric for JWKS/RSA keys).
+	Algorithms           []string          `yaml:"algorithms,omitempty" json:"algorithms,omitempty"`
 	Secret               string            `yaml:"secret,omitempty" json:"secret"`
 	PublicKey            string            `yaml:"publicKey,omitempty" json:"publicKey"`
 	Issuer               string            `yaml:"issuer,omitempty" json:"issuer"`


### PR DESCRIPTION
feat(jwt): add  list, deprecate single
Let JWT middlewares declare multiple accepted signing algorithms via a new
 list, superseding the single