### PR TITLE
feat(middleware): add geoBlock country-based access control

### DIFF
--- a/docs/middlewares/geo-block.md
+++ b/docs/middlewares/geo-block.md
@@ -1,0 +1,151 @@
+---
+title: Geo Block
+layout: default
+parent: Middlewares
+nav_order: 19
+---
+
+# Geo Block Middleware
+
+The Geo Block middleware provides country-based access control for routes, allowing or denying requests based on the client's country resolved from a GeoIP database. It applies globally to the route, so there is no need to configure path-level restrictions.
+
+## Overview
+
+The `geoBlock` middleware resolves the client's country from its IP address (using the configured GeoIP database) and enforces a policy:
+
+- **ALLOW**: only the listed countries may access the route (allowlist).
+- **DENY**: the listed countries are blocked; everyone else is allowed (blocklist).
+
+It can also enrich the upstream request with the resolved country header, so your backend can localize content, prices, or behavior without shipping its own GeoIP database.
+
+Privacy note: the client IP is used only to look up the country at the edge and is never forwarded — only the ISO country code is.
+
+## Prerequisites
+
+The middleware requires a GeoIP database in MaxMind `.mmdb` format. Both MaxMind (`GeoLite2-Country.mmdb`) and IP2Location (`IP2LOCATION-*.MMDB`) are supported — both expose a `country.iso_code`.
+
+Set the path with the `GOMA_GEOIP_DB` environment variable (default `/etc/goma/GeoLite2-Country.mmdb`):
+
+```bash
+GOMA_GEOIP_DB=/etc/goma/GeoLite2-Country.mmdb
+```
+
+If the database is absent or unreadable, country resolution is disabled and the middleware follows its `allowUnknown` setting (fail-open by default), so a missing database never locks everyone out.
+
+## Configuration
+
+### Basic Structure
+
+```yaml
+middlewares:
+  - name: <middleware-name>
+    type: geoBlock
+    rule:
+      action: <ALLOW|DENY>
+      countries:
+        - <ISO-3166-1-alpha-2>
+```
+
+### Parameters
+
+| Parameter               | Type    | Required | Default | Description                                                                                                   |
+|-------------------------|---------|----------|---------|---------------------------------------------------------------------------------------------------------------|
+| `action`                | String  | Yes      | —       | Policy action. `ALLOW` (allowlist) or `DENY` (blocklist).                                                      |
+| `countries`             | Array   | Yes      | —       | List of ISO 3166-1 alpha-2 country codes (e.g. `US`, `FR`, `DE`).                                              |
+| `statusCode`            | Integer | No       | `403`   | HTTP status returned for a blocked request.                                                                    |
+| `message`               | String  | No       | `Access denied from your region` | Response body message for a blocked request.                                        |
+| `allowUnknown`          | Boolean | No       | `true`  | What to do when the country can't be resolved (no database, private IP, lookup miss). `true` allows (fail-open); `false` blocks (fail-closed). |
+| `addCountryHeader`      | String  | No       | —       | When set, the resolved country is added to the upstream request under this header (e.g. `X-Country-Code`).     |
+
+### Behavior
+
+- **Country codes** are ISO 3166-1 alpha-2 and matched case-insensitively.
+- **Private and loopback clients bypass** the check — internal, mesh, and health-check traffic (loopback, RFC 1918 private, link-local) is never geo-fenced.
+- **Unresolved country** follows `allowUnknown`. The default is fail-open, so an absent or unreadable database can't block legitimate traffic.
+- **`addCountryHeader`** is applied to allowed requests too, making the middleware usable purely for enrichment (combine with a permissive rule).
+
+## Configuration Examples
+
+### Example 1: Allowlist (only these countries)
+
+```yaml
+middlewares:
+  - name: eu-only
+    type: geoBlock
+    rule:
+      action: ALLOW
+      countries:
+        - FR
+        - DE
+        - ES
+        - IT
+      message: "This service is only available in the EU."
+```
+
+### Example 2: Blocklist (deny specific countries)
+
+```yaml
+middlewares:
+  - name: sanctions-block
+    type: geoBlock
+    rule:
+      action: DENY
+      countries:
+        - KP
+        - IR
+      statusCode: 451   # Unavailable For Legal Reasons
+```
+
+### Example 3: Fail-closed (deny anything un-geolocated)
+
+```yaml
+middlewares:
+  - name: strict-us-only
+    type: geoBlock
+    rule:
+      action: ALLOW
+      countries: [US]
+      allowUnknown: false   # unresolved country is blocked
+```
+
+### Example 4: Country enrichment for the upstream
+
+```yaml
+middlewares:
+  - name: geo-header
+    type: geoBlock
+    rule:
+      action: DENY
+      countries: []          # blocks nothing
+      addCountryHeader: X-Country-Code
+```
+
+> To enrich without blocking, use a `DENY` action with an empty (or non-matching) country list; every request passes and carries the `X-Country-Code` header upstream.
+
+## Applying the Middleware
+
+Reference the middleware by name on a route:
+
+```yaml
+routes:
+  - name: my-app
+    path: /
+    hosts:
+      - app.example.com
+    backends:
+      - endpoint: http://backend:8080
+    middlewares:
+      - eu-only
+```
+
+Order matters: place `geoBlock` before authentication and rate-limiting middlewares so blocked regions are rejected as early as possible.
+
+## Metrics
+
+Denied requests are counted by the Prometheus metric:
+
+```
+gateway_geoblock_denied_total{name="<middleware-name>", country="<ISO code>"}
+```
+
+Combined with `gateway_requests_by_country_total`, this lets you monitor how much traffic each rule rejects and from where.

--- a/docs/middlewares/overview.md
+++ b/docs/middlewares/overview.md
@@ -28,6 +28,8 @@ With Goma, you can create custom middleware tailored to your needs and apply the
   - Validates user permissions or access rights for specific route paths.
 - **Access Policy Middleware**
   - Controls route access by either `allowing` or `denying` requests based on defined rules.
+- **Geo Block Middleware**
+  - Controls route access by country (GeoIP), `allowing` or `denying` requests, with optional country-header enrichment for the upstream.
 
 Middleware provides a flexible and powerful way to enhance the functionality, security, and performance of your API.
 

--- a/docs/operator-manual/middlware.md
+++ b/docs/operator-manual/middlware.md
@@ -36,6 +36,7 @@ The `spec.rule` field is a free-form object whose shape depends on `spec.type`. 
 | `responseHeaders` | Add / remove response headers. |
 | `errorInterceptor` | Map upstream error codes to custom responses. |
 | `userAgentBlock` | Block requests by User-Agent pattern. |
+| `geoBlock` | Allow / deny requests by country (GeoIP). |
 
 ## Basic auth
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -525,6 +525,24 @@ func (u UserAgentBlockRuleMiddleware) validate() error {
 	return nil
 }
 
+// validate validates GeoBlockRuleMiddleware
+func (g GeoBlockRuleMiddleware) validate() error {
+	switch strings.ToUpper(g.Action) {
+	case "ALLOW", "DENY":
+	default:
+		return fmt.Errorf("invalid action %q in geoBlock middleware (want ALLOW or DENY)", g.Action)
+	}
+	if len(g.Countries) == 0 {
+		return fmt.Errorf("empty countries in geoBlock middleware")
+	}
+	for _, c := range g.Countries {
+		if len(strings.TrimSpace(c)) != 2 {
+			return fmt.Errorf("invalid country %q in geoBlock middleware (want ISO 3166-1 alpha-2, e.g. US)", c)
+		}
+	}
+	return nil
+}
+
 // validate validates BasicRuleMiddleware
 func (basicAuth *BasicRuleMiddleware) validate() error {
 	if len(basicAuth.Users) == 0 {

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -62,6 +62,7 @@ const (
 	responseHeaders     MiddlewareType = "responseHeaders"
 	requestHeaders      MiddlewareType = "requestHeaders"
 	errorInterceptor    MiddlewareType = "errorInterceptor"
+	geoBlock            MiddlewareType = "geoBlock"
 )
 
 // ************** CORS ***************

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -18,10 +18,11 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"os"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // PrometheusMetrics defines all Prometheus metrics tracked by the gateway.
@@ -74,6 +75,9 @@ type PrometheusMetrics struct {
 	// bounded (~250 values), so it is safe as a label — unlike per-path. Only
 	// recorded when a country is resolved (a GeoIP database is configured).
 	GatewayRequestsByCountry *prometheus.CounterVec
+	// GatewayGeoBlockDenied counts requests denied by a geoBlock middleware,
+	// labeled by middleware name and the client country (ISO code).
+	GatewayGeoBlockDenied *prometheus.CounterVec
 }
 
 // NewPrometheusMetrics initializes and registers all Prometheus metrics for the gateway.
@@ -150,6 +154,13 @@ func NewPrometheusMetrics(startTime time.Time, stop chan os.Signal) *PrometheusM
 			prometheus.CounterOpts{
 				Name: "gateway_requests_by_country_total",
 				Help: "Total requests labeled by route name and client country (ISO code, from GeoIP)",
+			},
+			[]string{"name", "country"},
+		),
+		GatewayGeoBlockDenied: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "gateway_geoblock_denied_total",
+				Help: "Total requests denied by a geoBlock middleware, labeled by middleware name and country",
 			},
 			[]string{"name", "country"},
 		),

--- a/internal/middleware.go
+++ b/internal/middleware.go
@@ -128,6 +128,8 @@ func (r *Route) applyMiddlewareByType(mid Middleware, router *mux.Router) {
 		applyBodyLimitMiddleware(mid, router)
 	case userAgentBlock:
 		applyUserAgentBlockMiddleware(mid, router)
+	case geoBlock:
+		applyGeoBlockMiddleware(mid, router)
 	case accessLog:
 		applyAccessLogMiddleware(mid, r)
 	case responseHeaders:
@@ -386,6 +388,40 @@ func applyUserAgentBlockMiddleware(mid Middleware, router *mux.Router) {
 		UserAgents: rule.UserAgents,
 	}
 	router.Use(userAgents.Middleware)
+}
+
+func applyGeoBlockMiddleware(mid Middleware, router *mux.Router) {
+	rule := &GeoBlockRuleMiddleware{}
+	if err := goutils.DeepCopy(rule, mid.Rule); err != nil {
+		logger.Error("Error applying middleware, middleware not applied", "error", err)
+		return
+	}
+	if err := rule.validate(); err != nil {
+		logger.Error("Error applying middleware, middleware not applied", "error", err)
+		return
+	}
+	countries := make(map[string]struct{}, len(rule.Countries))
+	for _, c := range rule.Countries {
+		countries[strings.ToUpper(strings.TrimSpace(c))] = struct{}{}
+	}
+	allowUnknown := true // fail-open: an absent/unreadable GeoIP DB never locks everyone out
+	if rule.AllowUnknown != nil {
+		allowUnknown = *rule.AllowUnknown
+	}
+	geo := middlewares.GeoBlock{
+		Name:          mid.Name,
+		Deny:          strings.EqualFold(rule.Action, "DENY"),
+		Countries:     countries,
+		StatusCode:    rule.StatusCode,
+		Message:       rule.Message,
+		AllowUnknown:  allowUnknown,
+		CountryHeader: rule.AddCountryHeader,
+		Resolve:       geoCountry,
+		OnDeny: func(country string) {
+			prometheusMetrics.GatewayGeoBlockDenied.WithLabelValues(mid.Name, country).Inc()
+		},
+	}
+	router.Use(geo.Middleware)
 }
 
 func applyAccessPolicyMiddleware(mid Middleware, route Route, router *mux.Router) {

--- a/internal/middlewares/geo_block_middleware.go
+++ b/internal/middlewares/geo_block_middleware.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package middlewares
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// GeoBlock is country-based access control. Deny=false makes Countries an
+// allowlist (only those pass); Deny=true makes it a blocklist. Country codes are
+// ISO 3166-1 alpha-2, resolved from the client IP by the injected Resolve func
+// (the gateway's GeoIP lookup). Private/loopback clients bypass the check, and an
+// unresolved country follows AllowUnknown (fail-open by default). CountryHeader,
+// when set, carries the resolved country to the upstream. The raw IP is used only
+// for the lookup and never leaves the gateway.
+type GeoBlock struct {
+	Name          string
+	Deny          bool
+	Countries     map[string]struct{}
+	StatusCode    int
+	Message       string
+	AllowUnknown  bool
+	CountryHeader string
+	Resolve       func(ip string) string
+	OnDeny        func(country string) // optional metrics hook
+}
+
+func (g GeoBlock) status() int {
+	if g.StatusCode > 0 {
+		return g.StatusCode
+	}
+	return http.StatusForbidden
+}
+
+func (g GeoBlock) message() string {
+	if g.Message != "" {
+		return g.Message
+	}
+	return "Access denied from your region"
+}
+
+// Middleware enforces the country policy.
+func (g GeoBlock) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if g.Resolve == nil || len(g.Countries) == 0 {
+			logger.Warn(">> GeoBlock: no GeoIP resolver or countries configured; passing through")
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ip := RealIP(r)
+		// Internal traffic (loopback/private/link-local) is never geo-fenced.
+		if isInternalIP(ip) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		country := strings.ToUpper(g.Resolve(ip))
+		if country == "" {
+			if g.AllowUnknown {
+				next.ServeHTTP(w, r)
+				return
+			}
+			g.deny(w, r, "")
+			return
+		}
+
+		_, listed := g.Countries[country]
+		blocked := (g.Deny && listed) || (!g.Deny && !listed)
+		if blocked {
+			g.deny(w, r, country)
+			return
+		}
+
+		if g.CountryHeader != "" {
+			r.Header.Set(g.CountryHeader, country)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (g GeoBlock) deny(w http.ResponseWriter, r *http.Request, country string) {
+	if g.OnDeny != nil {
+		g.OnDeny(country)
+	}
+	logger.Warn("Blocked request",
+		"ip", RealIP(r),
+		"path", r.URL.Path,
+		"country", country,
+		"reason", "country not allowed",
+	)
+	RespondWithError(w, r, g.status(), g.message(), nil, getContentType(r))
+}
+
+// isInternalIP reports whether ip is loopback, private, link-local or
+// unspecified — traffic that shouldn't be geolocated or blocked.
+func isInternalIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback() || parsed.IsPrivate() || parsed.IsLinkLocalUnicast() || parsed.IsUnspecified()
+}

--- a/internal/middlewares/geo_block_middleware_test.go
+++ b/internal/middlewares/geo_block_middleware_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func countrySet(cc ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(cc))
+	for _, c := range cc {
+		m[c] = struct{}{}
+	}
+	return m
+}
+
+// serve runs a request with the given remote IP through g and returns the status
+// plus the country header the upstream saw (if any).
+func serve(g GeoBlock, remoteIP string) (int, string) {
+	var seen string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if g.CountryHeader != "" {
+			seen = r.Header.Get(g.CountryHeader)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteIP + ":12345"
+	rec := httptest.NewRecorder()
+	g.Middleware(next).ServeHTTP(rec, req)
+	return rec.Code, seen
+}
+
+func TestGeoBlockAllowlist(t *testing.T) {
+	// ALLOW: only FR/DE pass.
+	g := GeoBlock{
+		Countries: countrySet("FR", "DE"),
+		Resolve:   func(ip string) string { return map[string]string{"1.1.1.1": "FR", "2.2.2.2": "US"}[ip] },
+	}
+	if code, _ := serve(g, "1.1.1.1"); code != http.StatusOK {
+		t.Errorf("FR should pass allowlist, got %d", code)
+	}
+	if code, _ := serve(g, "2.2.2.2"); code != http.StatusForbidden {
+		t.Errorf("US should be blocked by allowlist, got %d", code)
+	}
+}
+
+func TestGeoBlockBlocklist(t *testing.T) {
+	// DENY: CN/RU blocked, everything else passes.
+	g := GeoBlock{
+		Deny:      true,
+		Countries: countrySet("CN", "RU"),
+		Resolve:   func(ip string) string { return map[string]string{"1.1.1.1": "CN", "2.2.2.2": "US"}[ip] },
+	}
+	if code, _ := serve(g, "1.1.1.1"); code != http.StatusForbidden {
+		t.Errorf("CN should be blocked by blocklist, got %d", code)
+	}
+	if code, _ := serve(g, "2.2.2.2"); code != http.StatusOK {
+		t.Errorf("US should pass blocklist, got %d", code)
+	}
+}
+
+func TestGeoBlockUnknownFailOpenAndClosed(t *testing.T) {
+	base := func(allowUnknown bool) GeoBlock {
+		return GeoBlock{
+			Countries:    countrySet("FR"),
+			AllowUnknown: allowUnknown,
+			Resolve:      func(ip string) string { return "" }, // unresolved
+		}
+	}
+	if code, _ := serve(base(true), "8.8.8.8"); code != http.StatusOK {
+		t.Errorf("fail-open: unknown should pass, got %d", code)
+	}
+	if code, _ := serve(base(false), "8.8.8.8"); code != http.StatusForbidden {
+		t.Errorf("fail-closed: unknown should be blocked, got %d", code)
+	}
+}
+
+func TestGeoBlockPrivateIPBypasses(t *testing.T) {
+	// A private client is never geo-fenced, even under a strict allowlist.
+	g := GeoBlock{
+		Countries:    countrySet("FR"),
+		AllowUnknown: false,
+		Resolve:      func(ip string) string { return "US" }, // would otherwise be blocked
+	}
+	if code, _ := serve(g, "10.1.2.3"); code != http.StatusOK {
+		t.Errorf("private IP should bypass geo check, got %d", code)
+	}
+}
+
+func TestGeoBlockCountryHeaderInjected(t *testing.T) {
+	g := GeoBlock{
+		Countries:     countrySet("US"),
+		CountryHeader: "X-Country-Code",
+		Resolve:       func(ip string) string { return "us" }, // lower-case, normalized to US
+	}
+	code, seen := serve(g, "3.3.3.3")
+	if code != http.StatusOK {
+		t.Fatalf("US should pass, got %d", code)
+	}
+	if seen != "US" {
+		t.Errorf("upstream country header = %q, want US", seen)
+	}
+}
+
+func TestGeoBlockCustomStatusAndDeny(t *testing.T) {
+	var denied string
+	g := GeoBlock{
+		Countries:  countrySet("FR"),
+		StatusCode: http.StatusTeapot,
+		Resolve:    func(ip string) string { return "US" },
+		OnDeny:     func(country string) { denied = country },
+	}
+	code, _ := serve(g, "4.4.4.4")
+	if code != http.StatusTeapot {
+		t.Errorf("custom status = %d, want 418", code)
+	}
+	if denied != "US" {
+		t.Errorf("OnDeny country = %q, want US", denied)
+	}
+}

--- a/internal/types.go
+++ b/internal/types.go
@@ -278,6 +278,16 @@ type AccessPolicyRuleMiddleware struct {
 type UserAgentBlockRuleMiddleware struct {
 	UserAgents []string `yaml:"userAgents" json:"userAgents"`
 }
+
+// GeoBlockRuleMiddleware is country-based access control backed by the GeoIP
+type GeoBlockRuleMiddleware struct {
+	Action           string   `yaml:"action,omitempty" json:"action"` // ALLOW or DENY
+	Countries        []string `yaml:"countries" json:"countries"`     // ISO 3166-1 alpha-2
+	StatusCode       int      `yaml:"statusCode,omitempty" json:"statusCode"`
+	Message          string   `yaml:"message,omitempty" json:"message"`
+	AllowUnknown     *bool    `yaml:"allowUnknown,omitempty" json:"allowUnknown"`
+	AddCountryHeader string   `yaml:"addCountryHeader,omitempty" json:"addCountryHeader"`
+}
 type ProxyMiddleware struct {
 	Name           string
 	Path           string


### PR DESCRIPTION
Introduce a geoBlock middleware that allows or denies requests by the client's country, resolved from the GeoIP database (GOMA_GEOIP_DB) that already powers analytics/metrics enrichment.