### PR TITLE
feat(geoip): default to country.mmdb, keep GeoLite2-Country.mmdb as f…

### DIFF
--- a/docs/middlewares/geo-block.md
+++ b/docs/middlewares/geo-block.md
@@ -22,13 +22,15 @@ Privacy note: the client IP is used only to look up the country at the edge and 
 
 ## Prerequisites
 
-The middleware requires a GeoIP database in MaxMind `.mmdb` format. Both MaxMind (`GeoLite2-Country.mmdb`) and IP2Location (`IP2LOCATION-*.MMDB`) are supported — both expose a `country.iso_code`.
+The middleware requires a country-level GeoIP database in MaxMind `.mmdb` format. MaxMind, DB-IP and IP2Location all publish one — any of them works, since all three expose a `country.iso_code`.
 
-Set the path with the `GOMA_GEOIP_DB` environment variable (default `/etc/goma/GeoLite2-Country.mmdb`):
+Save it as **`/etc/goma/country.mmdb`** and Goma picks it up with no configuration. To keep it elsewhere, set `GOMA_GEOIP_DB`:
 
 ```bash
-GOMA_GEOIP_DB=/etc/goma/GeoLite2-Country.mmdb
+GOMA_GEOIP_DB=/srv/geoip/dbip-country-lite.mmdb
 ```
+
+An explicit `GOMA_GEOIP_DB` is used exactly as given — Goma will not quietly fall back to another file, because geo rules deciding on a database nobody chose is worse than geo rules that do not run.
 
 If the database is absent or unreadable, country resolution is disabled and the middleware follows its `allowUnknown` setting (fail-open by default), so a missing database never locks everyone out.
 

--- a/docs/monitoring-and-performance/analytics.md
+++ b/docs/monitoring-and-performance/analytics.md
@@ -48,7 +48,7 @@ GOMA_ANALYTICS_ENABLED=true          # off by default
 GOMA_ANALYTICS_STREAM=goma:analytics # Redis stream key
 GOMA_REDIS_DB=0                      # must match the consumer's Redis DB
 # Optional country enrichment (see GeoIP below):
-GOMA_GEOIP_DB=/etc/goma/GeoLite2-Country.mmdb
+GOMA_GEOIP_DB=/etc/goma/country.mmdb
 ```
 
 ### Configuration (environment)
@@ -61,7 +61,7 @@ GOMA_GEOIP_DB=/etc/goma/GeoLite2-Country.mmdb
 | `GOMA_ANALYTICS_MAXLEN` | `1000000` | Approximate stream length cap (`XADD MAXLEN ~`). |
 | `GOMA_GATEWAY_ID` | `""` | Identifier stamped on each event (`gw`); useful with multiple gateways. |
 | `GOMA_REDIS_DB` | `0` | Redis database index (must match the consumer). |
-| `GOMA_GEOIP_DB` | `/etc/goma/GeoLite2-Country.mmdb` | Path to the GeoIP `.mmdb` for the `country` field. |
+| `GOMA_GEOIP_DB` | `/etc/goma/country.mmdb` | Path to the GeoIP `.mmdb` for the `country` field. |
 
 ### Event schema
 
@@ -88,9 +88,16 @@ Each stream entry has a single field `e` whose value is the JSON below.
 
 ### GeoIP (country enrichment)
 
-Set `GOMA_GEOIP_DB` to a MaxMind-format `.mmdb` (both MaxMind
-`GeoLite2-Country.mmdb` and IP2Location `IP2LOCATION-*.MMDB` work — both expose a
-country ISO code). It enriches the `country` field on events, the
+Save a country-level `.mmdb` database at **`/etc/goma/country.mmdb`** and Goma
+loads it at startup with no configuration; `GOMA_GEOIP_DB` overrides the path.
+MaxMind, DB-IP and IP2Location all publish a suitable database — any of them
+works, since all three expose a country ISO code.
+
+It enriches the `country` field on events, the
 `gateway_requests_by_country_total` metric, and powers the
 [`geoBlock`](../middlewares/geo-block.md) middleware. Everything keeps working
 without it — you just lose the country dimension.
+
+Goma ships no database: the ones worth having carry licenses that bind whoever
+uses or displays the data, which is a choice only you can make for your
+deployment.

--- a/internal/geoip.go
+++ b/internal/geoip.go
@@ -19,38 +19,56 @@ package internal
 
 import (
 	"net"
+	"strings"
 	"sync"
 
 	goutils "github.com/jkaninda/go-utils"
 	"github.com/oschwald/geoip2-golang"
 )
 
-// defaultGeoIPPath is where Miabi drops the GeoIP database into the gateway.
-// The .mmdb format is used by both MaxMind (GeoLite2-Country.mmdb) and
-// IP2Location (IP2LOCATION-*.MMDB) — both expose a `country.iso_code`, so one
-// reader covers either provider. Override with GOMA_GEOIP_DB.
-const defaultGeoIPPath = "/etc/goma/GeoLite2-Country.mmdb"
+// defaultGeoIPPaths are the databases Goma looks for when GOMA_GEOIP_DB is unset,
+// tried in order.
+//
+// `country.mmdb` is the provider-neutral name, and the one the docs use: the .mmdb
+// format is shared by MaxMind, DB-IP and IP2Location, and all three expose a
+// `country.iso_code`, so one reader covers whichever the operator supplied — naming
+// the file after any one of them was always a little wrong.
+//
+// GeoLite2-Country.mmdb stays as a fallback. It is what Goma defaulted to, and what
+// MaxMind's own download is called, so operators land on it without thinking.
+var defaultGeoIPPaths = []string{
+	"/etc/goma/country.mmdb",
+	"/etc/goma/GeoLite2-Country.mmdb",
+}
 
 var (
 	geoOnce   sync.Once
 	geoReader *geoip2.Reader
 )
 
-// initGeoIP opens the GeoIP database once, from GOMA_GEOIP_DB (default
-// /etc/goma/GeoLite2-Country.mmdb). It is a no-op — country enrichment stays
-// off, `geoCountry` returns "" — when the file is absent or unreadable, so
-// analytics keeps working without geo. Called from initAnalytics.
+// initGeoIP opens the GeoIP database once: GOMA_GEOIP_DB if set, otherwise the
+// first of defaultGeoIPPaths that opens. It is a no-op — country enrichment stays
+// off, `geoCountry` returns "" — when no database is readable, so analytics keeps
+// working without geo. Called from initAnalytics.
 func initGeoIP() {
 	geoOnce.Do(func() {
-		path := goutils.Env("GOMA_GEOIP_DB", defaultGeoIPPath)
-		r, err := geoip2.Open(path)
-		if err != nil {
-			logger.Warn("GeoIP database not loaded; country enrichment disabled",
-				"path", path, "error", err)
+		paths := defaultGeoIPPaths
+		if p := strings.TrimSpace(goutils.Env("GOMA_GEOIP_DB", "")); p != "" {
+			paths = []string{p}
+		}
+		var lastErr error
+		for _, path := range paths {
+			r, err := geoip2.Open(path)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			geoReader = r
+			logger.Info("GeoIP database loaded", "path", path)
 			return
 		}
-		geoReader = r
-		logger.Info("GeoIP database loaded", "path", path)
+		logger.Warn("GeoIP database not loaded; country enrichment disabled",
+			"paths", paths, "error", lastErr)
 	})
 }
 


### PR DESCRIPTION
…allback

initGeoIP now tries /etc/goma/country.mmdb first and falls back to /etc/goma/GeoLite2-Country.mmdb, so existing deployments keep working with no action. The docs use the neutral name only.