### PR TITLE
feat(oauth): verify sessions and forward user claims upstream

### DIFF
--- a/docs/middlewares/jwt.md
+++ b/docs/middlewares/jwt.md
@@ -99,12 +99,13 @@ rule:
 | `audience`         | string | Expected `aud` claim value                     | `"api.example.com"`                         |
 | `claimsExpression` | string | Boolean expression for custom claim validation | See [Claims Validation](#claims-validation) |
 
-### Header Forwarding
+### Claim Forwarding
 
-| Option                 | Type    | Description                                                              |
-|------------------------|---------|--------------------------------------------------------------------------|
-| `forwardHeaders`       | map     | Forward JWT claims as HTTP headers to upstream services                  |
-| `forwardAuthorization` | boolean | Whether to forward the original `Authorization` header (default: `true`) |
+| Option                 | Type    | Description                                                                     |
+|------------------------|---------|---------------------------------------------------------------------------------|
+| `forward`              | map     | Project claims onto the upstream request as headers, query parameters and cookies |
+| `forwardHeaders`       | map     | Deprecated: use `forward.headers`                                                |
+| `forwardAuthorization` | boolean | Whether to forward the original `Authorization` header (default: `true`)         |
 
 ## Claims Validation
 
@@ -143,18 +144,48 @@ claimsExpression: >
   !Equals('suspended', true)
 ```
 
-## Header Forwarding
+## Claim Forwarding
 
-Forward JWT claims as HTTP headers to your upstream services:
+Project verified claims onto the request sent to your upstream services:
 
 ```yaml
-forwardHeaders:
-  X-User-ID: sub                    # Standard claim
-  X-User-Email: email               # Standard claim  
-  X-User-Role: user.role            # Nested claim (dot notation)
-  X-Department: profile.department  # Deeply nested claim
-  X-Is-Admin: permissions.admin     # Boolean claims become "true"/"false"
+forward:
+  headers:
+    X-User-ID: sub                    # Standard claim
+    X-User-Email: email               # Standard claim
+    X-User-Role: user.role            # Nested claim (dot notation)
+    X-Department: profile.department  # Deeply nested claim
+    X-Is-Admin: permissions.admin     # Boolean claims become "true"/"false"
+    X-User-Roles: roles               # Array claims are joined with ","
+    X-User-Name: "{{ .given_name }} {{ .family_name }}"   # Template
+  query:
+    uid: sub
+  cookies:
+    app_user: email
 ```
+
+| Option           | Type    | Description                                                                                          |
+|------------------|---------|--------------------------------------------------------------------------------------------------------|
+| `headers`        | map     | Header name → claim path or template.                                                                   |
+| `query`          | map     | Query parameter → claim path or template.                                                               |
+| `cookies`        | map     | Cookie name → claim path or template. Added to the upstream request only, never to the client response. |
+| `stripInbound`   | boolean | Remove client-supplied copies of every mapped key. Default `true`.                                      |
+| `arraySeparator` | string  | Joins array claims. Default `,`.                                                                        |
+| `encoding`       | string  | `auto` (default) base64-encodes non-ASCII values and flags them with a `<Header>-Encoding` companion header; `raw` passes them through. |
+| `maxValueBytes`  | int     | Bounds a single projected value. Default `4096`.                                                        |
+
+Every mapped key is removed from the incoming request before the verified value
+is set, on every path of the route — including the ones this middleware does not
+guard. Without that, a client could send `X-User-Email: admin@example.com` and
+your backend would believe it. Set `stripInbound: false` only when nothing but
+the gateway can reach the upstream.
+
+Control characters are always removed from forwarded values, so a claim a user
+can set for themselves cannot inject a second header into the proxied request.
+
+The deprecated flat `forwardHeaders` map still works and is merged into
+`forward.headers`, which takes precedence key by key. The same claim path syntax
+is used by the [OAuth middleware](oauth.md).
 
 ## Complete Examples
 
@@ -188,12 +219,13 @@ middlewares:
         Equals('email_verified', true) &&
         OneOf('department', 'engineering', 'product', 'security') &&
         !Equals('account_disabled', true)
-      forwardHeaders:
-        X-User-ID: sub
-        X-User-Email: email
-        X-User-Name: name
-        X-User-Department: department
-        X-User-Roles: roles
+      forward:
+        headers:
+          X-User-ID: sub
+          X-User-Email: email
+          X-User-Name: name
+          X-User-Department: department
+          X-User-Roles: roles
 ```
 
 ### Multi-Tenant SaaS
@@ -210,8 +242,9 @@ middlewares:
         Equals('email_verified', true) &&
         Contains('scopes', 'api:read') &&
         OneOf('tenant_role', 'admin', 'user', 'viewer')
-      forwardHeaders:
-        X-Tenant-ID: tenant_id
-        X-User-Role: tenant_role
-        X-Permissions: scopes
+      forward:
+        headers:
+          X-Tenant-ID: tenant_id
+          X-User-Role: tenant_role
+          X-Permissions: scopes
 ```

--- a/docs/middlewares/oauth.md
+++ b/docs/middlewares/oauth.md
@@ -7,7 +7,128 @@ nav_order: 6
 
 # OAuth middleware
 
-### Example of Google provider
+The OAuth middleware terminates the browser login flow at the gateway. It sends
+unauthenticated users to your identity provider, verifies the session on every
+request, and projects the authenticated user's claims onto the proxied request
+so your backends can stay stateless and never handle a token.
+
+## How a session is verified
+
+Every request carrying a session is verified before it reaches your backend:
+
+| Token shape                                        | How it is verified                                                                 |
+|----------------------------------------------------|------------------------------------------------------------------------------------|
+| JWT access token, `endpoint.jwksUrl` configured    | Signature against the provider's JWKS, plus `exp`, and `iss`/`aud` when configured |
+| Opaque access token (Google, GitHub, Facebook)     | The provider's `endpoint.userInfoUrl`, whose response also supplies the claims      |
+| ID token (`id_token`), `endpoint.jwksUrl` configured | Signature, `exp`, and `aud` — which must be this middleware's `clientId`           |
+
+Only asymmetric signing algorithms are accepted, so a token cannot be forged by
+signing `HS256` with the provider's public key as the HMAC secret.
+
+**At least one of `endpoint.jwksUrl` or `endpoint.userInfoUrl` is required.**
+Without one the gateway has no way to tell a token issued by your provider from
+one a client made up, so the middleware refuses to load rather than appear to
+guard the route. For the well-known providers both are filled in for you.
+
+User info responses are cached for 60 seconds per token, which is also how long
+a token revoked at the provider keeps working when the provider issues opaque
+tokens.
+
+## Configuration
+
+| Option                | Type   | Description                                                                                   |
+|-----------------------|--------|-----------------------------------------------------------------------------------------------|
+| `clientId`            | string | The application's client ID. Required.                                                         |
+| `clientSecret`        | string | The application's client secret. Required.                                                     |
+| `provider`            | string | `google`, `gitlab`, `github`, `amazon`, `facebook` or `custom`. Defaults to `custom`.           |
+| `endpoint.authUrl`    | string | Authorization endpoint. Filled in for known providers.                                          |
+| `endpoint.tokenUrl`   | string | Token endpoint. Filled in for known providers.                                                  |
+| `endpoint.jwksUrl`    | string | JWKS used to verify JWT access tokens and ID tokens.                                            |
+| `endpoint.userInfoUrl`| string | User info endpoint, used to verify opaque tokens and to read claims.                             |
+| `redirectUrl`         | string | Callback URL registered with the provider. Required.                                            |
+| `redirectPath`        | string | Path to send the user to after login, e.g. `/dashboard`.                                        |
+| `cookiePath`          | string | Path the session cookies are scoped to. Defaults to the route path.                             |
+| `scopes`              | list   | Requested scopes.                                                                               |
+| `state`               | string | Opaque state value sent to the provider.                                                        |
+| `issuer`              | string | Enforced as the `iss` claim on JWT tokens when set.                                             |
+| `audience`            | string | Enforced as the `aud` claim on JWT **access** tokens when set.                                   |
+| `claimsSource`        | list   | Where claims are read from, in increasing precedence: `access_token`, `userinfo`, `id_token`.    |
+| `forward`             | map    | How the user's claims are projected onto the upstream request. See below.                        |
+
+Session cookies (`goma_access_token`, `goma_refresh_token`, `goma_id_token`) are
+issued as `HttpOnly`, `SameSite=Lax`, and `Secure` whenever the request arrived
+over TLS.
+
+Requests without a valid session are redirected to the provider only when the
+caller is a browser navigating. API clients and XHR/`fetch` requests receive a
+`401` with a `WWW-Authenticate` header instead of a redirect they cannot follow.
+
+## Forwarding user info to your backend
+
+`forward` projects the verified claims onto the proxied request as headers,
+query parameters and cookies:
+
+```yaml
+    forward:
+      headers:
+        X-Auth-User: sub
+        X-Auth-Email: email
+        X-Auth-Name: "{{ .given_name }} {{ .family_name }}"   # template
+        X-Auth-Groups: groups                                  # array → "a,b"
+        X-Auth-Tenant: resource_access.app.tenant              # nested claim
+      query:
+        uid: sub
+      cookies:
+        app_user: email
+      accessTokenHeader: Authorization                         # Bearer <token>
+```
+
+| Option              | Type    | Description                                                                                          |
+|---------------------|---------|--------------------------------------------------------------------------------------------------------|
+| `headers`           | map     | Header name → claim path or template.                                                                   |
+| `query`             | map     | Query parameter → claim path or template.                                                               |
+| `cookies`           | map     | Cookie name → claim path or template. Added to the upstream request only, never to the client response. |
+| `stripInbound`      | boolean | Remove client-supplied copies of every mapped key. Default `true`.                                      |
+| `arraySeparator`    | string  | Joins array claims such as `groups`. Default `,`.                                                       |
+| `encoding`          | string  | `auto` (default) or `raw`. See [Encoding](#encoding).                                                   |
+| `maxValueBytes`     | int     | Bounds a single projected value. Default `4096`.                                                        |
+| `accessTokenHeader` | string  | Forward the raw access token, e.g. `Authorization` or `X-Auth-Access-Token`.                             |
+| `idTokenHeader`     | string  | Forward the raw ID token, e.g. `X-Auth-Id-Token`.                                                       |
+
+### Claim paths and templates
+
+A value is either a claim path — with dot notation for nested objects, such as
+`resource_access.app.tenant` — or a template interpolating several of them,
+such as `{{ .given_name }} {{ .family_name }}`. Arrays are joined with
+`arraySeparator`; booleans become `true`/`false`; nested objects are forwarded
+as compact JSON. A claim that is not present leaves the key absent rather than
+forwarding an empty value.
+
+The same syntax is used by the [JWT middleware](jwt.md), so a claim path means
+the same thing wherever you write it.
+
+### Do not disable `stripInbound`
+
+Every mapped key is removed from the incoming request before the verified value
+is set, on every path of the route — including the ones this middleware does
+not guard. Without that, a client can simply send `X-Auth-Email: admin@example.com`
+and your backend will believe it. Set `stripInbound: false` only when nothing
+but the gateway can reach the upstream.
+
+Plain headers are only as trustworthy as the network path between the gateway
+and your backend. On an untrusted network, prefer having the backend verify the
+token itself via `accessTokenHeader` or `idTokenHeader`.
+
+### Encoding
+
+HTTP headers are restricted to ASCII. With `encoding: auto`, a value that is
+not pure ASCII — a display name, typically — is base64-encoded and flagged with
+a companion header, so `X-Auth-Name` arrives with `X-Auth-Name-Encoding: base64`.
+Use `encoding: raw` to pass values through untouched. Control characters are
+always removed, so a claim a user can set for themselves cannot inject a second
+header into the proxied request.
+
+## Example: Google
 
 ```yaml
 middlewares:
@@ -21,16 +142,23 @@ middlewares:
       # oauth provider google, gitlab, github, amazon, facebook, custom
       provider: google # facebook, gitlab, github, amazon
       redirectUrl: https://example.com/callback/protected
-      #RedirectPath is the PATH to redirect users after authentication, e.g: /my-protected-path/dashboard
+      # RedirectPath is the PATH to redirect users after authentication, e.g: /my-protected-path/dashboard
       redirectPath: /dashboard
       scopes:
         - https://www.googleapis.com/auth/userinfo.email
         - https://www.googleapis.com/auth/userinfo.profile
       state: randomStateString
-
+      forward:
+        headers:
+          X-Auth-User: id
+          X-Auth-Email: email
+          X-Auth-Name: name
 ```
 
-### Example of Authentik provider
+Google issues opaque access tokens, so sessions are verified against Google's
+user info endpoint, which is also where these claims come from.
+
+## Example: Authentik
 
 ```yaml
 middlewares:
@@ -49,16 +177,26 @@ middlewares:
           tokenUrl: https://authentik.example.com/application/o/token/
           userInfoUrl: https://authentik.example.com/application/o/userinfo/
           jwksUrl: https://authentik.example.com/application/o/goma/jwks/
+        issuer: https://authentik.example.com/application/o/goma/
         redirectUrl: https://example.com/callback # Goma will use the callback path as path
-        #RedirectPath is the PATH to redirect users after authentication, e.g: /my-protected-path/dashboard
+        # RedirectPath is the PATH to redirect users after authentication, e.g: /my-protected-path/dashboard
         redirectPath: ''
-        #CookiePath e.g.: /my-protected-path or / || by default is applied on a route path
+        # CookiePath e.g.: /my-protected-path or / || by default is applied on a route path
         cookiePath: "/"
         scopes:
           - email
           - openid
+          - profile
         state: randomStateString
+        forward:
+          headers:
+            X-Auth-User: sub
+            X-Auth-Email: email
+            X-Auth-Name: "{{ .given_name }} {{ .family_name }}"
+            X-Auth-Groups: groups
+          accessTokenHeader: Authorization
 ```
+
 ### Apply middleware on the route
 
 ```yaml
@@ -75,3 +213,14 @@ middlewares:
       middlewares:
         - oauth-authentik
 ```
+
+## Current limitations
+
+- `state` is a fixed configured value rather than a per-request random value,
+  and the flow does not yet use PKCE or an OIDC `nonce`.
+- After login the user lands on `redirectPath`, not on the URL they originally
+  requested.
+- There is no logout endpoint; clearing the session cookies ends the session.
+- Sessions live entirely in the browser's cookies. Each request refreshes on its
+  own, so with a provider that rotates refresh tokens, concurrent requests can
+  race.

--- a/internal/config.go
+++ b/internal/config.go
@@ -864,22 +864,22 @@ func claimMapper(rule *ForwardClaimsRule, legacyHeaders map[string]string) *midd
 // need spelled out in the configuration.
 func (oauthRuler *OauthRulerMiddleware) applyProviderDefaults() {
 	if oauthRuler.Provider == "" {
-		oauthRuler.Provider = "custom"
+		oauthRuler.Provider = middlewares.ProviderCustom
 	}
 	switch oauthRuler.Provider {
-	case "google":
+	case middlewares.ProviderGoogle:
 		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://www.googleapis.com/oauth2/v2/userinfo")
 		setIfEmpty(&oauthRuler.Endpoint.JwksURL, "https://www.googleapis.com/oauth2/v3/certs")
-	case "facebook":
+	case middlewares.ProviderFacebook:
 		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://graph.facebook.com/me?fields=id,name,email")
-	case "github":
+	case middlewares.ProviderGitHub:
 		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://api.github.com/user")
-	case "gitlab":
+	case middlewares.ProviderGitLab:
 		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://gitlab.com/oauth/userinfo")
 		setIfEmpty(&oauthRuler.Endpoint.JwksURL, "https://gitlab.com/oauth/discovery/keys")
-	case "amazon":
+	case middlewares.ProviderAmazon:
 		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://api.amazon.com/user/profile")
-	case "custom":
+	case middlewares.ProviderCustom:
 	default:
 		logger.Error("Unknown oauth provider", "provider", oauthRuler.Provider)
 	}
@@ -921,15 +921,15 @@ func oauth2Config(oauth *OauthRulerMiddleware) *oauth2.Config {
 	}
 	oauth.applyProviderDefaults()
 	switch oauth.Provider {
-	case "google":
+	case middlewares.ProviderGoogle:
 		conf.Endpoint = google.Endpoint
-	case "amazon":
+	case middlewares.ProviderAmazon:
 		conf.Endpoint = amazon.Endpoint
-	case "facebook":
+	case middlewares.ProviderFacebook:
 		conf.Endpoint = facebook.Endpoint
-	case "github":
+	case middlewares.ProviderGitHub:
 		conf.Endpoint = github.Endpoint
-	case "gitlab":
+	case middlewares.ProviderGitLab:
 		conf.Endpoint = gitlab.Endpoint
 	}
 	return conf

--- a/internal/config.go
+++ b/internal/config.go
@@ -20,6 +20,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -32,6 +33,7 @@ import (
 	"github.com/jkaninda/goma-gateway/pkg/plugins"
 	"github.com/jkaninda/goma-gateway/util"
 	logger2 "github.com/jkaninda/logger"
+
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/amazon"
 	"golang.org/x/oauth2/facebook"
@@ -793,13 +795,102 @@ func (l LogEnrichRule) validate() error {
 
 // oAuthMiddleware returns OauthRulerMiddleware, error
 func (oauthRuler *OauthRulerMiddleware) validate() error {
-	if oauthRuler.ClientID == "" || oauthRuler.ClientSecret == "" || oauthRuler.RedirectURL == "" {
-		return fmt.Errorf("error parsing yaml: empty clientId/secretId in %s middlewares", oauthRuler)
+	oauthRuler.applyProviderDefaults()
 
+	if oauthRuler.ClientID == "" || oauthRuler.ClientSecret == "" || oauthRuler.RedirectURL == "" {
+		return fmt.Errorf("error parsing yaml: empty clientId/clientSecret/redirectUrl in oauth middleware for provider %q", oauthRuler.Provider)
+	}
+
+	if oauthRuler.Endpoint.JwksURL == "" && oauthRuler.Endpoint.UserInfoURL == "" {
+		return fmt.Errorf("error parsing yaml: oauth middleware requires endpoint.jwksUrl or endpoint.userInfoUrl to verify tokens")
+	}
+	for _, source := range oauthRuler.ClaimsSource {
+		switch source {
+		case middlewares.ClaimSourceIDToken, middlewares.ClaimSourceUserInfo, middlewares.ClaimSourceAccessToken:
+		default:
+			return fmt.Errorf("error parsing yaml: unknown claimsSource %q, expected one of id_token, userinfo, access_token", source)
+		}
+	}
+	return oauthRuler.Forward.validate()
+}
+
+// validate checks the claim projection rule.
+func (f *ForwardClaimsRule) validate() error {
+	if f == nil {
+		return nil
+	}
+	switch f.Encoding {
+	case "", middlewares.ClaimEncodingAuto, middlewares.ClaimEncodingRaw:
+	default:
+		return fmt.Errorf("error parsing yaml: unknown forward.encoding %q, expected auto or raw", f.Encoding)
+	}
+	if f.StripInbound != nil && !*f.StripInbound {
+		logger.Warn("Claim forwarding has stripInbound disabled, clients can forge the forwarded identity headers")
 	}
 	return nil
 }
-func oauthRulerMiddleware(oauth middlewares.Oauth) *OauthRulerMiddleware {
+
+// claimMapper builds the shared claim projector. legacyHeaders carries the
+// deprecated flat forwardHeaders map; keys also present in forward.headers are
+// overridden by it.
+func claimMapper(rule *ForwardClaimsRule, legacyHeaders map[string]string) *middlewares.ClaimMapper {
+	mapper := &middlewares.ClaimMapper{}
+	if len(legacyHeaders) > 0 {
+		mapper.Headers = maps.Clone(legacyHeaders)
+	}
+	if rule != nil {
+		if len(rule.Headers) > 0 {
+			if mapper.Headers == nil {
+				mapper.Headers = make(map[string]string, len(rule.Headers))
+			}
+			maps.Copy(mapper.Headers, rule.Headers)
+		}
+		mapper.Query = rule.Query
+		mapper.Cookies = rule.Cookies
+		mapper.StripInbound = rule.StripInbound
+		mapper.ArraySeparator = rule.ArraySeparator
+		mapper.Encoding = rule.Encoding
+		mapper.MaxValueBytes = rule.MaxValueBytes
+		mapper.AccessTokenHeader = rule.AccessTokenHeader
+		mapper.IDTokenHeader = rule.IDTokenHeader
+	}
+	if !mapper.Enabled() {
+		return nil
+	}
+	return mapper
+}
+
+// applyProviderDefaults fills in the endpoints a well-known provider does not
+// need spelled out in the configuration.
+func (oauthRuler *OauthRulerMiddleware) applyProviderDefaults() {
+	if oauthRuler.Provider == "" {
+		oauthRuler.Provider = "custom"
+	}
+	switch oauthRuler.Provider {
+	case "google":
+		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://www.googleapis.com/oauth2/v2/userinfo")
+		setIfEmpty(&oauthRuler.Endpoint.JwksURL, "https://www.googleapis.com/oauth2/v3/certs")
+	case "facebook":
+		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://graph.facebook.com/me?fields=id,name,email")
+	case "github":
+		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://api.github.com/user")
+	case "gitlab":
+		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://gitlab.com/oauth/userinfo")
+		setIfEmpty(&oauthRuler.Endpoint.JwksURL, "https://gitlab.com/oauth/discovery/keys")
+	case "amazon":
+		setIfEmpty(&oauthRuler.Endpoint.UserInfoURL, "https://api.amazon.com/user/profile")
+	case "custom":
+	default:
+		logger.Error("Unknown oauth provider", "provider", oauthRuler.Provider)
+	}
+}
+
+func setIfEmpty(field *string, value string) {
+	if *field == "" {
+		*field = value
+	}
+}
+func oauthRulerMiddleware(oauth *middlewares.Oauth) *OauthRulerMiddleware {
 	return &OauthRulerMiddleware{
 		ClientID:     oauth.ClientID,
 		ClientSecret: oauth.ClientSecret,
@@ -813,6 +904,8 @@ func oauthRulerMiddleware(oauth middlewares.Oauth) *OauthRulerMiddleware {
 			UserInfoURL: oauth.Endpoint.UserInfoURL,
 			JwksURL:     oauth.Endpoint.JwksURL,
 		},
+		Issuer:   oauth.Issuer,
+		Audience: oauth.Audience,
 	}
 }
 func oauth2Config(oauth *OauthRulerMiddleware) *oauth2.Config {
@@ -826,31 +919,18 @@ func oauth2Config(oauth *OauthRulerMiddleware) *oauth2.Config {
 			TokenURL: oauth.Endpoint.TokenURL,
 		},
 	}
+	oauth.applyProviderDefaults()
 	switch oauth.Provider {
 	case "google":
 		conf.Endpoint = google.Endpoint
-		if oauth.Endpoint.UserInfoURL == "" {
-			oauth.Endpoint.UserInfoURL = "https://www.googleapis.com/oauth2/v2/userinfo"
-		}
 	case "amazon":
 		conf.Endpoint = amazon.Endpoint
 	case "facebook":
 		conf.Endpoint = facebook.Endpoint
-		if oauth.Endpoint.UserInfoURL == "" {
-			oauth.Endpoint.UserInfoURL = "https://graph.facebook.com/me"
-		}
 	case "github":
 		conf.Endpoint = github.Endpoint
-		if oauth.Endpoint.UserInfoURL == "" {
-			oauth.Endpoint.UserInfoURL = "https://api.github.com/user/repo"
-		}
 	case "gitlab":
 		conf.Endpoint = gitlab.Endpoint
-	default:
-		if oauth.Provider != "custom" {
-			logger.Error(fmt.Sprintf("Unknown provider: %s", oauth.Provider))
-		}
-
 	}
 	return conf
 }

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -31,6 +31,7 @@ const (
 	RequestIDHeader                      = "X-Goma-Request-ID"
 	GomaAccessToken                      = "goma_access_token"
 	GomaRefreshToken                     = "goma_refresh_token"
+	GomaIDToken                          = "goma_id_token"
 	StatusClientClosedRequest            = 499
 	acmeServerURL                        = "localhost:5002"
 	visitorPrefix                        = "visitor-"

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -226,18 +226,15 @@ func (oauthRuler *OauthRulerMiddleware) callbackHandler(w http.ResponseWriter, r
 		http.Error(w, "Failed to exchange token", http.StatusInternalServerError)
 		return
 	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     GomaAccessToken,
-		Value:    token.AccessToken,
-		Path:     oauthRuler.CookiePath,
-		HttpOnly: true,
-	})
-	http.SetCookie(w, &http.Cookie{
-		Name:     GomaRefreshToken,
-		Value:    token.RefreshToken,
-		Path:     oauthRuler.CookiePath,
-		HttpOnly: true,
-	})
+	http.SetCookie(w, middlewares.NewAuthCookie(r, GomaAccessToken, token.AccessToken, oauthRuler.CookiePath))
+	if token.RefreshToken != "" {
+		http.SetCookie(w, middlewares.NewAuthCookie(r, GomaRefreshToken, token.RefreshToken, oauthRuler.CookiePath))
+	}
+	// The ID token is the provider's identity assertion: it is what the
+	// middleware verifies and reads the user's claims from.
+	if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
+		http.SetCookie(w, middlewares.NewAuthCookie(r, GomaIDToken, idToken, oauthRuler.CookiePath))
+	}
 
 	// Redirect to the home page or another protected route
 	http.Redirect(w, r, oauthRuler.RedirectPath, http.StatusSeeOther)

--- a/internal/middleware.go
+++ b/internal/middleware.go
@@ -611,7 +611,7 @@ func applyJWTAuthMiddleware(route Route, routeMiddleware Middleware, r *njia.Gro
 		Path:                 route.Path,
 		Paths:                routeMiddleware.Paths,
 		ClaimsExpression:     rule.ClaimsExpression,
-		ForwardHeaders:       rule.ForwardHeaders,
+		Forward:              claimMapper(rule.Forward, rule.ForwardHeaders),
 		ForwardAuthorization: rule.ForwardAuthorization,
 		RsaKey:               key,
 		Algo:                 rule.Alg,
@@ -677,7 +677,7 @@ func applyOAuthMiddleware(route Route, routeMiddleware Middleware, r *njia.Group
 		redirectURL = rule.RedirectURL
 	}
 
-	amw := middlewares.Oauth{
+	amw := &middlewares.Oauth{
 		Path:         route.Path,
 		Paths:        routeMiddleware.Paths,
 		ClientID:     rule.ClientID,
@@ -690,10 +690,14 @@ func applyOAuthMiddleware(route Route, routeMiddleware Middleware, r *njia.Group
 			UserInfoURL: rule.Endpoint.UserInfoURL,
 			JwksURL:     rule.Endpoint.JwksURL,
 		},
-		State:      rule.State,
-		Origins:    route.Cors.Origins,
-		CookiePath: cookiePath,
-		Provider:   rule.Provider,
+		State:        rule.State,
+		Origins:      route.Cors.Origins,
+		CookiePath:   cookiePath,
+		Provider:     rule.Provider,
+		Issuer:       rule.Issuer,
+		Audience:     rule.Audience,
+		ClaimsSource: rule.ClaimsSource,
+		Forward:      claimMapper(rule.Forward, nil),
 	}
 
 	oauthRuler := oauthRulerMiddleware(amw)

--- a/internal/middleware.go
+++ b/internal/middleware.go
@@ -706,10 +706,6 @@ func applyOAuthMiddleware(route Route, routeMiddleware Middleware, r *njia.Group
 	if oauthRuler.RedirectPath == "" {
 		oauthRuler.RedirectPath = util.ParseRoutePath(route.Path, routeMiddleware.Paths[0])
 	}
-	if oauthRuler.Provider == "" {
-		oauthRuler.Provider = "custom"
-	}
-
 	r.Use(amw.AuthMiddleware)
 	// The callback lives inside the route's group, so it is wrapped by the same
 	// middleware, and its exact path outranks the route's catch-all.

--- a/internal/middlewares/claims.go
+++ b/internal/middlewares/claims.go
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2024 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package middlewares
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	// DefaultArraySeparator joins multi-valued claims such as "groups".
+	DefaultArraySeparator = ","
+	// DefaultMaxClaimValueBytes bounds a single projected value. Most upstream
+	// servers reject a request whose total header block exceeds 8KB, so a
+	// group-heavy token must not be able to make every request unroutable.
+	DefaultMaxClaimValueBytes = 4096
+	// encodingHeaderSuffix names the companion header that tells the upstream a
+	// value was base64-encoded because it contained non-ASCII characters.
+	encodingHeaderSuffix = "-Encoding"
+
+	// ClaimEncodingAuto base64-encodes values that are not pure ASCII.
+	ClaimEncodingAuto = "auto"
+	// ClaimEncodingRaw passes values through untouched (control characters are
+	// still removed).
+	ClaimEncodingRaw = "raw"
+)
+
+// ClaimMapper projects verified identity claims onto the upstream request as
+// headers, query parameters and cookies. It is shared by every middleware that
+// authenticates a user (JWT, OAuth/OIDC) so a claim path means the same thing
+// everywhere.
+//
+// A value is either a claim path with dot notation for nested objects
+// ("resource_access.app.tenant") or a template interpolating several of them
+// ("{{ .given_name }} {{ .family_name }}").
+type ClaimMapper struct {
+	// Headers, Query and Cookies map a destination key to a claim path or
+	// template. Cookies are added to the upstream request only, never to the
+	// client response.
+	Headers map[string]string
+	Query   map[string]string
+	Cookies map[string]string
+
+	// ArraySeparator joins array claims. Defaults to DefaultArraySeparator.
+	ArraySeparator string
+
+	// Encoding is ClaimEncodingAuto (default) or ClaimEncodingRaw. Header values
+	// are restricted to ASCII by RFC 9110; "auto" base64-encodes anything else
+	// and flags it with a "<Name>-Encoding: base64" companion header, so a user
+	// whose display name is not ASCII does not silently reach the backend as
+	// mojibake.
+	Encoding string
+
+	// MaxValueBytes bounds a single value. Defaults to DefaultMaxClaimValueBytes.
+	MaxValueBytes int
+
+	// StripInbound removes any client-supplied copy of every mapped key before
+	// projecting. Nil means enabled. Disabling it lets a client forge its own
+	// identity headers, so it is only safe when nothing but the gateway can
+	// reach the upstream.
+	StripInbound *bool
+
+	// AccessTokenHeader and IDTokenHeader forward the raw tokens when set. The
+	// value is the bare token except on "Authorization", where the header's own
+	// grammar requires the "Bearer " prefix.
+	AccessTokenHeader string
+	IDTokenHeader     string
+}
+
+// Enabled reports whether the mapper has anything to project.
+func (m *ClaimMapper) Enabled() bool {
+	if m == nil {
+		return false
+	}
+	return len(m.Headers) > 0 || len(m.Query) > 0 || len(m.Cookies) > 0 ||
+		m.AccessTokenHeader != "" || m.IDTokenHeader != ""
+}
+
+func (m *ClaimMapper) separator() string {
+	if m.ArraySeparator == "" {
+		return DefaultArraySeparator
+	}
+	return m.ArraySeparator
+}
+
+func (m *ClaimMapper) maxValueBytes() int {
+	if m.MaxValueBytes <= 0 {
+		return DefaultMaxClaimValueBytes
+	}
+	return m.MaxValueBytes
+}
+
+func (m *ClaimMapper) stripsInbound() bool {
+	return m.StripInbound == nil || *m.StripInbound
+}
+
+// Apply strips client-supplied copies of the mapped keys and projects the
+// claims onto r. Claims that cannot be resolved leave the key absent, which is
+// why stripping happens first and unconditionally.
+func (m *ClaimMapper) Apply(r *http.Request, claims map[string]interface{}) {
+	if !m.Enabled() {
+		return
+	}
+	if m.stripsInbound() {
+		m.Strip(r)
+	}
+
+	for name, expr := range m.Headers {
+		value, ok := m.resolve(claims, expr)
+		if !ok {
+			continue
+		}
+		encoded, isEncoded, ok := m.encodeValue(value)
+		if !ok {
+			logger.Warn("Claim value too large to forward, header skipped",
+				"header", name, "bytes", len(value), "limit", m.maxValueBytes())
+			continue
+		}
+		r.Header.Set(name, encoded)
+		if isEncoded {
+			r.Header.Set(name+encodingHeaderSuffix, "base64")
+		}
+	}
+
+	if len(m.Query) > 0 {
+		query := r.URL.Query()
+		for name, expr := range m.Query {
+			value, ok := m.resolve(claims, expr)
+			if !ok {
+				continue
+			}
+			query.Set(name, value)
+		}
+		r.URL.RawQuery = query.Encode()
+	}
+
+	for name, expr := range m.Cookies {
+		value, ok := m.resolve(claims, expr)
+		if !ok {
+			continue
+		}
+		// Percent-encode: cookie values may not carry ";", "," or spaces, and Go
+		// would otherwise drop the whole cookie when writing it out.
+		r.AddCookie(&http.Cookie{Name: name, Value: url.QueryEscape(value)})
+	}
+}
+
+// Strip removes every mapped key that the client supplied. Without it a client
+// can simply send "X-Auth-Email: admin@example.com" and impersonate anyone.
+func (m *ClaimMapper) Strip(r *http.Request) {
+	if m == nil {
+		return
+	}
+	for name := range m.Headers {
+		r.Header.Del(name)
+		r.Header.Del(name + encodingHeaderSuffix)
+	}
+	if m.AccessTokenHeader != "" {
+		r.Header.Del(m.AccessTokenHeader)
+	}
+	if m.IDTokenHeader != "" {
+		r.Header.Del(m.IDTokenHeader)
+	}
+	if len(m.Query) > 0 {
+		query := r.URL.Query()
+		for name := range m.Query {
+			query.Del(name)
+		}
+		r.URL.RawQuery = query.Encode()
+	}
+	deleteRequestCookies(r, m.Cookies)
+}
+
+// ForwardTokens attaches the raw tokens to the upstream request when the mapper
+// is configured to do so.
+func (m *ClaimMapper) ForwardTokens(r *http.Request, accessToken, idToken string) {
+	if m == nil {
+		return
+	}
+	if m.AccessTokenHeader != "" && accessToken != "" {
+		r.Header.Set(m.AccessTokenHeader, bearerValue(m.AccessTokenHeader, accessToken))
+	}
+	if m.IDTokenHeader != "" && idToken != "" {
+		r.Header.Set(m.IDTokenHeader, bearerValue(m.IDTokenHeader, idToken))
+	}
+}
+
+func bearerValue(header, token string) string {
+	if strings.EqualFold(header, "Authorization") {
+		return "Bearer " + token
+	}
+	return token
+}
+
+// resolve turns a claim path or template into a string. It reports false when
+// nothing resolved, so the caller can leave the key absent rather than
+// forwarding an empty value that an upstream might read as "anonymous".
+func (m *ClaimMapper) resolve(claims map[string]interface{}, expr string) (string, bool) {
+	var value string
+	if strings.Contains(expr, "{{") {
+		value = m.renderTemplate(claims, expr)
+	} else {
+		claimValue, err := ExtractClaim(claims, expr)
+		if err != nil {
+			logger.Debug("Claim not found, key not forwarded", "claim", expr, "error", err)
+			return "", false
+		}
+		value = FormatClaimValue(claimValue, m.separator())
+	}
+
+	value = sanitizeValue(value)
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+// renderTemplate interpolates "{{ .claim.path }}" placeholders. Unresolved
+// placeholders render as empty rather than as an error marker so a partially
+// populated token still yields a usable value.
+func (m *ClaimMapper) renderTemplate(claims map[string]interface{}, expr string) string {
+	var out strings.Builder
+	rest := expr
+	for {
+		start := strings.Index(rest, "{{")
+		if start < 0 {
+			out.WriteString(rest)
+			return out.String()
+		}
+		end := strings.Index(rest[start:], "}}")
+		if end < 0 {
+			out.WriteString(rest)
+			return out.String()
+		}
+		end += start
+		out.WriteString(rest[:start])
+
+		path := strings.TrimSpace(rest[start+2 : end])
+		path = strings.TrimPrefix(path, ".")
+		if path != "" {
+			if claimValue, err := ExtractClaim(claims, path); err == nil {
+				out.WriteString(FormatClaimValue(claimValue, m.separator()))
+			} else {
+				logger.Debug("Claim not found while rendering template", "claim", path, "template", expr)
+			}
+		}
+		rest = rest[end+2:]
+	}
+}
+
+// encodeValue applies the configured encoding and enforces the size bound.
+func (m *ClaimMapper) encodeValue(value string) (string, bool, bool) {
+	if isASCII(value) || m.Encoding == ClaimEncodingRaw {
+		if len(value) > m.maxValueBytes() {
+			return "", false, false
+		}
+		return value, false, true
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(value))
+	if len(encoded) > m.maxValueBytes() {
+		return "", false, false
+	}
+	return encoded, true, true
+}
+
+// ExtractClaim reads a claim using dot notation for nested objects, e.g.
+// "resource_access.myapp.tenant".
+func ExtractClaim(claims map[string]interface{}, claimPath string) (interface{}, error) {
+	if claimPath == "" {
+		return nil, fmt.Errorf("empty claim path")
+	}
+	keys := strings.Split(claimPath, ".")
+	var current interface{} = claims
+
+	for i, key := range keys {
+		object, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannot traverse claim path at key '%s' (expected object, got %T)", key, current)
+		}
+		value, exists := object[key]
+		if !exists {
+			return nil, fmt.Errorf("claim key '%s' not found at path '%s'", key, strings.Join(keys[:i+1], "."))
+		}
+		current = value
+	}
+	return current, nil
+}
+
+// FormatClaimValue renders a claim value as a single string.
+func FormatClaimValue(claimValue interface{}, separator string) string {
+	if separator == "" {
+		separator = DefaultArraySeparator
+	}
+	switch value := claimValue.(type) {
+	case nil:
+		return ""
+	case string:
+		return value
+	case bool:
+		return strconv.FormatBool(value)
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(value), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(value)
+	case int64:
+		return strconv.FormatInt(value, 10)
+	case json.Number:
+		return value.String()
+	case []interface{}:
+		parts := make([]string, 0, len(value))
+		for _, item := range value {
+			parts = append(parts, FormatClaimValue(item, separator))
+		}
+		return strings.Join(parts, separator)
+	case []string:
+		return strings.Join(value, separator)
+	case map[string]interface{}:
+		// Nested objects are forwarded as compact JSON so an upstream can parse
+		// them instead of receiving Go's map formatting.
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return ""
+		}
+		return string(encoded)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+// sanitizeValue removes control characters. CR and LF in particular would let a
+// claim an upstream identity provider lets users set (a display name, say)
+// inject additional headers into the proxied request.
+func sanitizeValue(value string) string {
+	if !strings.ContainsFunc(value, isControl) {
+		return strings.TrimSpace(value)
+	}
+	var out strings.Builder
+	out.Grow(len(value))
+	for _, r := range value {
+		if isControl(r) {
+			continue
+		}
+		out.WriteRune(r)
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func isControl(r rune) bool {
+	return r < 0x20 || r == 0x7f
+}
+
+func isASCII(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// deleteRequestCookies rewrites the request's Cookie header without the named
+// cookies.
+func deleteRequestCookies(r *http.Request, names map[string]string) {
+	if len(names) == 0 || r.Header.Get("Cookie") == "" {
+		return
+	}
+	kept := make([]*http.Cookie, 0, len(r.Cookies()))
+	for _, cookie := range r.Cookies() {
+		if _, mapped := names[cookie.Name]; mapped {
+			continue
+		}
+		kept = append(kept, cookie)
+	}
+	r.Header.Del("Cookie")
+	for _, cookie := range kept {
+		r.AddCookie(cookie)
+	}
+}
+
+// claimsFromMap normalizes any claim carrier (jwt.MapClaims, decoded JSON) into
+// a plain map.
+func claimsFromMap(claims map[string]interface{}) map[string]interface{} {
+	if claims == nil {
+		return map[string]interface{}{}
+	}
+	return claims
+}
+
+// mergeClaims copies src over dst, so callers can layer claim sources in
+// increasing order of precedence.
+func mergeClaims(dst, src map[string]interface{}) map[string]interface{} {
+	if dst == nil {
+		dst = map[string]interface{}{}
+	}
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}

--- a/internal/middlewares/claims_test.go
+++ b/internal/middlewares/claims_test.go
@@ -27,28 +27,28 @@ import (
 
 func testClaims() map[string]interface{} {
 	return map[string]interface{}{
-		"sub":            "user-1",
-		"email":          "ada@example.com",
+		claimSub:         testSubject,
+		claimEmail:       testEmail,
 		"email_verified": true,
 		"given_name":     "Ada",
 		"family_name":    "Lovelace",
-		"groups":         []interface{}{"admins", "engineering"},
-		"exp":            float64(1893456000),
+		claimGroups:      []interface{}{testGroup, "engineering"},
+		claimExp:         float64(1893456000),
 		"resource_access": map[string]interface{}{
-			"app": map[string]interface{}{"tenant": "acme"},
+			"app": map[string]interface{}{"tenant": testTenant},
 		},
 	}
 }
 
 func TestClaimMapperHeaders(t *testing.T) {
 	mapper := &ClaimMapper{Headers: map[string]string{
-		"X-Auth-User":     "sub",
-		"X-Auth-Email":    "email",
+		headerUser:        claimSub,
+		headerEmail:       "email",
 		"X-Auth-Verified": "email_verified",
-		"X-Auth-Groups":   "groups",
+		headerGroup:       "groups",
 		"X-Auth-Tenant":   "resource_access.app.tenant",
-		"X-Auth-Name":     "{{ .given_name }} {{ .family_name }}",
-		"X-Auth-Expiry":   "exp",
+		headerName:        "{{ .given_name }} {{ .family_name }}",
+		"X-Auth-Expiry":   claimExp,
 		"X-Auth-Missing":  "does_not_exist",
 	}}
 
@@ -56,12 +56,12 @@ func TestClaimMapperHeaders(t *testing.T) {
 	mapper.Apply(request, testClaims())
 
 	expected := map[string]string{
-		"X-Auth-User":     "user-1",
-		"X-Auth-Email":    "ada@example.com",
+		headerUser:        testSubject,
+		headerEmail:       testEmail,
 		"X-Auth-Verified": "true",
-		"X-Auth-Groups":   "admins,engineering",
-		"X-Auth-Tenant":   "acme",
-		"X-Auth-Name":     "Ada Lovelace",
+		headerGroup:       testGroup + ",engineering",
+		"X-Auth-Tenant":   testTenant,
+		headerName:        "Ada Lovelace",
 		"X-Auth-Expiry":   "1893456000",
 	}
 	for header, want := range expected {
@@ -77,41 +77,41 @@ func TestClaimMapperHeaders(t *testing.T) {
 // A client must never be able to supply its own identity headers.
 func TestClaimMapperStripsInboundHeaders(t *testing.T) {
 	mapper := &ClaimMapper{Headers: map[string]string{
-		"X-Auth-Email": "email",
-		"X-Auth-Role":  "role", // Not present in the claims.
+		headerEmail:   claimEmail,
+		"X-Auth-Role": "role", // Not present in the claims.
 	}}
 
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
-	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set(headerEmail, "attacker@example.com")
 	request.Header.Set("X-Auth-Role", "admin")
-	request.Header.Set("X-Auth-Email-Encoding", "base64")
+	request.Header.Set(headerEmail+encodingHeaderSuffix, "base64")
 	mapper.Apply(request, testClaims())
 
-	if got := request.Header.Get("X-Auth-Email"); got != "ada@example.com" {
-		t.Errorf("X-Auth-Email = %q, want the verified claim", got)
+	if got := request.Header.Get(headerEmail); got != testEmail {
+		t.Errorf("%s = %q, want the verified claim", headerEmail, got)
 	}
 	if got := request.Header.Get("X-Auth-Role"); got != "" {
 		t.Errorf("X-Auth-Role = %q, want the client value to be stripped", got)
 	}
-	if got := request.Header.Get("X-Auth-Email-Encoding"); got != "" {
+	if got := request.Header.Get(headerEmail + encodingHeaderSuffix); got != "" {
 		t.Errorf("X-Auth-Email-Encoding = %q, want the client value to be stripped", got)
 	}
 }
 
 func TestClaimMapperStripsInboundQueryAndCookies(t *testing.T) {
 	mapper := &ClaimMapper{
-		Query:   map[string]string{"uid": "sub"},
-		Cookies: map[string]string{"app_user": "email", "app_role": "role"},
+		Query:   map[string]string{"uid": claimSub},
+		Cookies: map[string]string{"app_user": claimEmail, "app_role": "role"},
 	}
 
-	request := httptest.NewRequest(http.MethodGet, "/api?uid=attacker&page=2", nil)
-	request.AddCookie(&http.Cookie{Name: "app_user", Value: "attacker"})
+	request := httptest.NewRequest(http.MethodGet, "/api?uid="+testAttacker+"&page=2", nil)
+	request.AddCookie(&http.Cookie{Name: "app_user", Value: testAttacker})
 	request.AddCookie(&http.Cookie{Name: "app_role", Value: "admin"})
 	request.AddCookie(&http.Cookie{Name: "session", Value: "keep-me"})
 	mapper.Apply(request, testClaims())
 
 	query := request.URL.Query()
-	if got := query.Get("uid"); got != "user-1" {
+	if got := query.Get("uid"); got != testSubject {
 		t.Errorf("uid = %q, want the verified claim", got)
 	}
 	if got := query.Get("page"); got != "2" {
@@ -136,13 +136,13 @@ func TestClaimMapperStripsInboundQueryAndCookies(t *testing.T) {
 // A claim an identity provider lets users set themselves must not be able to
 // inject a second header into the proxied request.
 func TestClaimMapperRejectsHeaderInjection(t *testing.T) {
-	mapper := &ClaimMapper{Headers: map[string]string{"X-Auth-Name": "name"}}
-	claims := map[string]interface{}{"name": "Ada\r\nX-Auth-Role: admin"}
+	mapper := &ClaimMapper{Headers: map[string]string{headerName: claimName}}
+	claims := map[string]interface{}{claimName: "Ada\r\nX-Auth-Role: admin"}
 
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	mapper.Apply(request, claims)
 
-	value := request.Header.Get("X-Auth-Name")
+	value := request.Header.Get(headerName)
 	if strings.ContainsAny(value, "\r\n") {
 		t.Fatalf("X-Auth-Name = %q, want control characters removed", value)
 	}
@@ -152,40 +152,40 @@ func TestClaimMapperRejectsHeaderInjection(t *testing.T) {
 }
 
 func TestClaimMapperEncodesNonASCII(t *testing.T) {
-	mapper := &ClaimMapper{Headers: map[string]string{"X-Auth-Name": "name"}}
-	claims := map[string]interface{}{"name": "Jönas Kaninda"}
+	mapper := &ClaimMapper{Headers: map[string]string{headerName: claimName}}
+	claims := map[string]interface{}{claimName: "Jönas Kaninda"}
 
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	mapper.Apply(request, claims)
 
 	want := base64.StdEncoding.EncodeToString([]byte("Jönas Kaninda"))
-	if got := request.Header.Get("X-Auth-Name"); got != want {
+	if got := request.Header.Get(headerName); got != want {
 		t.Errorf("X-Auth-Name = %q, want %q", got, want)
 	}
-	if got := request.Header.Get("X-Auth-Name-Encoding"); got != "base64" {
+	if got := request.Header.Get(headerName + encodingHeaderSuffix); got != "base64" {
 		t.Errorf("X-Auth-Name-Encoding = %q, want base64", got)
 	}
 
-	raw := &ClaimMapper{Headers: map[string]string{"X-Auth-Name": "name"}, Encoding: ClaimEncodingRaw}
+	raw := &ClaimMapper{Headers: map[string]string{headerName: claimName}, Encoding: ClaimEncodingRaw}
 	request = httptest.NewRequest(http.MethodGet, "/", nil)
 	raw.Apply(request, claims)
-	if got := request.Header.Get("X-Auth-Name"); got != "Jönas Kaninda" {
+	if got := request.Header.Get(headerName); got != "Jönas Kaninda" {
 		t.Errorf("raw encoding: X-Auth-Name = %q, want the value unchanged", got)
 	}
 }
 
 func TestClaimMapperBoundsValueSize(t *testing.T) {
 	mapper := &ClaimMapper{
-		Headers:       map[string]string{"X-Auth-Groups": "groups"},
+		Headers:       map[string]string{headerGroup: claimGroups},
 		MaxValueBytes: 8,
 	}
-	claims := map[string]interface{}{"groups": []interface{}{"a-very-long-group-name", "another-one"}}
+	claims := map[string]interface{}{claimGroups: []interface{}{"a-very-long-group-name", "another-one"}}
 
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
-	request.Header.Set("X-Auth-Groups", "spoofed")
+	request.Header.Set(headerGroup, "spoofed")
 	mapper.Apply(request, claims)
 
-	if got := request.Header.Get("X-Auth-Groups"); got != "" {
+	if got := request.Header.Get(headerGroup); got != "" {
 		t.Errorf("X-Auth-Groups = %q, want oversized value dropped and inbound value stripped", got)
 	}
 }
@@ -209,13 +209,13 @@ func TestClaimMapperForwardTokens(t *testing.T) {
 
 func TestClaimMapperCustomArraySeparator(t *testing.T) {
 	mapper := &ClaimMapper{
-		Headers:        map[string]string{"X-Auth-Groups": "groups"},
+		Headers:        map[string]string{headerGroup: claimGroups},
 		ArraySeparator: "|",
 	}
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	mapper.Apply(request, testClaims())
 
-	if got := request.Header.Get("X-Auth-Groups"); got != "admins|engineering" {
+	if got := request.Header.Get(headerGroup); got != testGroup+"|engineering" {
 		t.Errorf("X-Auth-Groups = %q, want admins|engineering", got)
 	}
 }
@@ -226,7 +226,7 @@ func TestClaimMapperDisabled(t *testing.T) {
 		t.Fatal("nil mapper reported as enabled")
 	}
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
-	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set(headerEmail, "attacker@example.com")
 	// A nil mapper must be inert, not panic.
 	mapper.Apply(request, testClaims())
 	mapper.Strip(request)
@@ -259,7 +259,7 @@ func TestFormatClaimValue(t *testing.T) {
 func TestExtractClaim(t *testing.T) {
 	claims := testClaims()
 
-	if value, err := ExtractClaim(claims, "resource_access.app.tenant"); err != nil || value != "acme" {
+	if value, err := ExtractClaim(claims, "resource_access.app.tenant"); err != nil || value != testTenant {
 		t.Errorf("ExtractClaim(nested) = %v, %v; want acme, nil", value, err)
 	}
 	if _, err := ExtractClaim(claims, "resource_access.missing.tenant"); err == nil {

--- a/internal/middlewares/claims_test.go
+++ b/internal/middlewares/claims_test.go
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2024 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package middlewares
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testClaims() map[string]interface{} {
+	return map[string]interface{}{
+		"sub":            "user-1",
+		"email":          "ada@example.com",
+		"email_verified": true,
+		"given_name":     "Ada",
+		"family_name":    "Lovelace",
+		"groups":         []interface{}{"admins", "engineering"},
+		"exp":            float64(1893456000),
+		"resource_access": map[string]interface{}{
+			"app": map[string]interface{}{"tenant": "acme"},
+		},
+	}
+}
+
+func TestClaimMapperHeaders(t *testing.T) {
+	mapper := &ClaimMapper{Headers: map[string]string{
+		"X-Auth-User":     "sub",
+		"X-Auth-Email":    "email",
+		"X-Auth-Verified": "email_verified",
+		"X-Auth-Groups":   "groups",
+		"X-Auth-Tenant":   "resource_access.app.tenant",
+		"X-Auth-Name":     "{{ .given_name }} {{ .family_name }}",
+		"X-Auth-Expiry":   "exp",
+		"X-Auth-Missing":  "does_not_exist",
+	}}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	mapper.Apply(request, testClaims())
+
+	expected := map[string]string{
+		"X-Auth-User":     "user-1",
+		"X-Auth-Email":    "ada@example.com",
+		"X-Auth-Verified": "true",
+		"X-Auth-Groups":   "admins,engineering",
+		"X-Auth-Tenant":   "acme",
+		"X-Auth-Name":     "Ada Lovelace",
+		"X-Auth-Expiry":   "1893456000",
+	}
+	for header, want := range expected {
+		if got := request.Header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+	if got := request.Header.Get("X-Auth-Missing"); got != "" {
+		t.Errorf("missing claim forwarded as %q, want no header", got)
+	}
+}
+
+// A client must never be able to supply its own identity headers.
+func TestClaimMapperStripsInboundHeaders(t *testing.T) {
+	mapper := &ClaimMapper{Headers: map[string]string{
+		"X-Auth-Email": "email",
+		"X-Auth-Role":  "role", // Not present in the claims.
+	}}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set("X-Auth-Role", "admin")
+	request.Header.Set("X-Auth-Email-Encoding", "base64")
+	mapper.Apply(request, testClaims())
+
+	if got := request.Header.Get("X-Auth-Email"); got != "ada@example.com" {
+		t.Errorf("X-Auth-Email = %q, want the verified claim", got)
+	}
+	if got := request.Header.Get("X-Auth-Role"); got != "" {
+		t.Errorf("X-Auth-Role = %q, want the client value to be stripped", got)
+	}
+	if got := request.Header.Get("X-Auth-Email-Encoding"); got != "" {
+		t.Errorf("X-Auth-Email-Encoding = %q, want the client value to be stripped", got)
+	}
+}
+
+func TestClaimMapperStripsInboundQueryAndCookies(t *testing.T) {
+	mapper := &ClaimMapper{
+		Query:   map[string]string{"uid": "sub"},
+		Cookies: map[string]string{"app_user": "email", "app_role": "role"},
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api?uid=attacker&page=2", nil)
+	request.AddCookie(&http.Cookie{Name: "app_user", Value: "attacker"})
+	request.AddCookie(&http.Cookie{Name: "app_role", Value: "admin"})
+	request.AddCookie(&http.Cookie{Name: "session", Value: "keep-me"})
+	mapper.Apply(request, testClaims())
+
+	query := request.URL.Query()
+	if got := query.Get("uid"); got != "user-1" {
+		t.Errorf("uid = %q, want the verified claim", got)
+	}
+	if got := query.Get("page"); got != "2" {
+		t.Errorf("page = %q, want unrelated query parameters preserved", got)
+	}
+
+	cookies := map[string]string{}
+	for _, cookie := range request.Cookies() {
+		cookies[cookie.Name] = cookie.Value
+	}
+	if cookies["app_user"] != "ada%40example.com" {
+		t.Errorf("app_user cookie = %q, want the verified claim", cookies["app_user"])
+	}
+	if _, present := cookies["app_role"]; present {
+		t.Errorf("app_role cookie = %q, want the client value to be stripped", cookies["app_role"])
+	}
+	if cookies["session"] != "keep-me" {
+		t.Errorf("session cookie = %q, want unrelated cookies preserved", cookies["session"])
+	}
+}
+
+// A claim an identity provider lets users set themselves must not be able to
+// inject a second header into the proxied request.
+func TestClaimMapperRejectsHeaderInjection(t *testing.T) {
+	mapper := &ClaimMapper{Headers: map[string]string{"X-Auth-Name": "name"}}
+	claims := map[string]interface{}{"name": "Ada\r\nX-Auth-Role: admin"}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	mapper.Apply(request, claims)
+
+	value := request.Header.Get("X-Auth-Name")
+	if strings.ContainsAny(value, "\r\n") {
+		t.Fatalf("X-Auth-Name = %q, want control characters removed", value)
+	}
+	if got := request.Header.Get("X-Auth-Role"); got != "" {
+		t.Errorf("X-Auth-Role = %q, want no injected header", got)
+	}
+}
+
+func TestClaimMapperEncodesNonASCII(t *testing.T) {
+	mapper := &ClaimMapper{Headers: map[string]string{"X-Auth-Name": "name"}}
+	claims := map[string]interface{}{"name": "Jönas Kaninda"}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	mapper.Apply(request, claims)
+
+	want := base64.StdEncoding.EncodeToString([]byte("Jönas Kaninda"))
+	if got := request.Header.Get("X-Auth-Name"); got != want {
+		t.Errorf("X-Auth-Name = %q, want %q", got, want)
+	}
+	if got := request.Header.Get("X-Auth-Name-Encoding"); got != "base64" {
+		t.Errorf("X-Auth-Name-Encoding = %q, want base64", got)
+	}
+
+	raw := &ClaimMapper{Headers: map[string]string{"X-Auth-Name": "name"}, Encoding: ClaimEncodingRaw}
+	request = httptest.NewRequest(http.MethodGet, "/", nil)
+	raw.Apply(request, claims)
+	if got := request.Header.Get("X-Auth-Name"); got != "Jönas Kaninda" {
+		t.Errorf("raw encoding: X-Auth-Name = %q, want the value unchanged", got)
+	}
+}
+
+func TestClaimMapperBoundsValueSize(t *testing.T) {
+	mapper := &ClaimMapper{
+		Headers:       map[string]string{"X-Auth-Groups": "groups"},
+		MaxValueBytes: 8,
+	}
+	claims := map[string]interface{}{"groups": []interface{}{"a-very-long-group-name", "another-one"}}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Auth-Groups", "spoofed")
+	mapper.Apply(request, claims)
+
+	if got := request.Header.Get("X-Auth-Groups"); got != "" {
+		t.Errorf("X-Auth-Groups = %q, want oversized value dropped and inbound value stripped", got)
+	}
+}
+
+func TestClaimMapperForwardTokens(t *testing.T) {
+	mapper := &ClaimMapper{AccessTokenHeader: "Authorization", IDTokenHeader: "X-Auth-Id-Token"}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer forged")
+	request.Header.Set("X-Auth-Id-Token", "forged")
+	mapper.Strip(request)
+	mapper.ForwardTokens(request, "access-token", "id-token")
+
+	if got := request.Header.Get("Authorization"); got != "Bearer access-token" {
+		t.Errorf("Authorization = %q, want the session's access token", got)
+	}
+	if got := request.Header.Get("X-Auth-Id-Token"); got != "id-token" {
+		t.Errorf("X-Auth-Id-Token = %q, want the session's ID token", got)
+	}
+}
+
+func TestClaimMapperCustomArraySeparator(t *testing.T) {
+	mapper := &ClaimMapper{
+		Headers:        map[string]string{"X-Auth-Groups": "groups"},
+		ArraySeparator: "|",
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	mapper.Apply(request, testClaims())
+
+	if got := request.Header.Get("X-Auth-Groups"); got != "admins|engineering" {
+		t.Errorf("X-Auth-Groups = %q, want admins|engineering", got)
+	}
+}
+
+func TestClaimMapperDisabled(t *testing.T) {
+	var mapper *ClaimMapper
+	if mapper.Enabled() {
+		t.Fatal("nil mapper reported as enabled")
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	// A nil mapper must be inert, not panic.
+	mapper.Apply(request, testClaims())
+	mapper.Strip(request)
+	mapper.ForwardTokens(request, "a", "b")
+}
+
+func TestFormatClaimValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"string", "value", "value"},
+		{"bool", true, "true"},
+		{"integral float", float64(42), "42"},
+		{"fractional float", 4.5, "4.5"},
+		{"nil", nil, ""},
+		{"string slice", []string{"a", "b"}, "a,b"},
+		{"object", map[string]interface{}{"tenant": "acme"}, `{"tenant":"acme"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := FormatClaimValue(test.value, DefaultArraySeparator); got != test.want {
+				t.Errorf("FormatClaimValue(%v) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestExtractClaim(t *testing.T) {
+	claims := testClaims()
+
+	if value, err := ExtractClaim(claims, "resource_access.app.tenant"); err != nil || value != "acme" {
+		t.Errorf("ExtractClaim(nested) = %v, %v; want acme, nil", value, err)
+	}
+	if _, err := ExtractClaim(claims, "resource_access.missing.tenant"); err == nil {
+		t.Error("ExtractClaim(missing) = nil error, want an error")
+	}
+	if _, err := ExtractClaim(claims, "email.nested"); err == nil {
+		t.Error("ExtractClaim(through a scalar) = nil error, want an error")
+	}
+	if _, err := ExtractClaim(claims, ""); err == nil {
+		t.Error("ExtractClaim(empty path) = nil error, want an error")
+	}
+}

--- a/internal/middlewares/config.go
+++ b/internal/middlewares/config.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-func oauth2Config(oauth Oauth) *oauth2.Config {
+func oauth2Config(oauth *Oauth) *oauth2.Config {
 	config := &oauth2.Config{
 		ClientID:     oauth.ClientID,
 		ClientSecret: oauth.ClientSecret,

--- a/internal/middlewares/config.go
+++ b/internal/middlewares/config.go
@@ -26,6 +26,16 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+// OAuth provider identifiers.
+const (
+	ProviderCustom   = "custom"
+	ProviderGoogle   = "google"
+	ProviderGitHub   = "github"
+	ProviderGitLab   = "gitlab"
+	ProviderAmazon   = "amazon"
+	ProviderFacebook = "facebook"
+)
+
 func oauth2Config(oauth *Oauth) *oauth2.Config {
 	config := &oauth2.Config{
 		ClientID:     oauth.ClientID,
@@ -38,18 +48,18 @@ func oauth2Config(oauth *Oauth) *oauth2.Config {
 		},
 	}
 	switch oauth.Provider {
-	case "google":
+	case ProviderGoogle:
 		config.Endpoint = google.Endpoint
-	case "amazon":
+	case ProviderAmazon:
 		config.Endpoint = amazon.Endpoint
-	case "facebook":
+	case ProviderFacebook:
 		config.Endpoint = facebook.Endpoint
-	case "github":
+	case ProviderGitHub:
 		config.Endpoint = github.Endpoint
-	case "gitlab":
+	case ProviderGitLab:
 		config.Endpoint = gitlab.Endpoint
 	default:
-		if oauth.Provider != "custom" {
+		if oauth.Provider != ProviderCustom {
 			logger.Error("Unknown provider,", "provider", oauth.Provider)
 		}
 

--- a/internal/middlewares/helpers.go
+++ b/internal/middlewares/helpers.go
@@ -160,7 +160,7 @@ func RespondWithErrorHTML(
 		return
 	}
 
-	if contentType == "text/html" {
+	if contentType == contentTypeHTML {
 		serveHTMLString(w, statusCode, logMessage)
 		return
 	}

--- a/internal/middlewares/jwt_middleware.go
+++ b/internal/middlewares/jwt_middleware.go
@@ -26,6 +26,10 @@ import (
 
 func (jwtAuth *JwtAuth) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Strip the keys the gateway owns before anything else, so a client
+		// cannot supply them on a path this middleware does not guard.
+		jwtAuth.Forward.Strip(r)
+
 		if !isPathMatching(r.URL.Path, jwtAuth.Path, jwtAuth.Paths) {
 			next.ServeHTTP(w, r)
 			return
@@ -83,12 +87,14 @@ func (jwtAuth *JwtAuth) AuthMiddleware(next http.Handler) http.Handler {
 			r.Header.Del("Authorization")
 		}
 
-		if jwtAuth.ForwardHeaders != nil {
-			if err := jwtAuth.forwardHeadersFromClaims(token, r.Header); err != nil {
-				logger.Error("Failed to forward headers from claims", "error", err)
+		if jwtAuth.Forward.Enabled() {
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				logger.Error("Failed to forward claims", "error", "invalid claims format")
 				RespondWithError(w, r, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), jwtAuth.Origins, contentType)
 				return
 			}
+			jwtAuth.Forward.Apply(r, claims)
 		}
 
 		next.ServeHTTP(w, r)
@@ -216,84 +222,4 @@ func (jwtAuth *JwtAuth) validateJWTClaims(token *jwt.Token) (bool, error) {
 	}
 
 	return true, nil // No claims validation configured
-}
-
-// forwardHeadersFromClaims extracts values from JWT claims and sets them as HTTP headers
-func (jwtAuth *JwtAuth) forwardHeadersFromClaims(token *jwt.Token, headers map[string][]string) error {
-	// Get claims as MapClaims
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return fmt.Errorf("invalid claims format")
-	}
-	// Process each header mapping
-	for headerName, claimPath := range jwtAuth.ForwardHeaders {
-		// Extract claim value using nested key traversal with dot notation support
-		claimValue, err := jwtAuth.extractNestedClaimValue(claims, claimPath)
-		if err != nil {
-			logger.Error("Warning: Could not extract claim", "claimPath", claimPath, "error", err)
-			continue
-		}
-
-		// Convert claim value to string
-		headerValue := jwtAuth.formatHeaderValue(claimValue)
-		if headerValue == "" {
-			continue // Skip empty values
-		}
-
-		// Set the header
-		if headers == nil {
-			headers = make(map[string][]string)
-		}
-		headers[headerName] = []string{headerValue}
-	}
-
-	return nil
-}
-
-// extractNestedClaimValue extracts a value from JWT claims using dot notation for nested keys
-func (jwtAuth *JwtAuth) extractNestedClaimValue(claims jwt.MapClaims, claimKey string) (interface{}, error) {
-	// Handle nested keys using dot notation (e.g., "user.profile.email")
-	keys := strings.Split(claimKey, ".")
-	var current interface{} = map[string]interface{}(claims)
-
-	// Traverse nested keys
-	for i, k := range keys {
-		if m, ok := current.(map[string]interface{}); ok {
-			if val, exists := m[k]; exists {
-				current = val
-			} else {
-				return nil, fmt.Errorf("claim key '%s' not found at path '%s'", k, strings.Join(keys[:i+1], "."))
-			}
-		} else {
-			return nil, fmt.Errorf("cannot traverse claim path at key '%s' (expected object, got %T)", k, current)
-		}
-	}
-
-	return current, nil
-}
-
-// formatHeaderValue converts a claim value to a header string
-func (jwtAuth *JwtAuth) formatHeaderValue(claimValue interface{}) string {
-	// Convert claim value to string
-	switch cv := claimValue.(type) {
-	case string:
-		return cv
-	case float64:
-		return fmt.Sprintf("%.0f", cv)
-	case bool:
-		return fmt.Sprintf("%t", cv)
-	case []interface{}:
-		// Join array values with comma
-		var strValues []string
-		for _, v := range cv {
-			if vStr, ok := v.(string); ok {
-				strValues = append(strValues, vStr)
-			} else {
-				strValues = append(strValues, fmt.Sprintf("%v", v))
-			}
-		}
-		return strings.Join(strValues, ",")
-	default:
-		return fmt.Sprintf("%v", cv)
-	}
 }

--- a/internal/middlewares/oauth_middleware.go
+++ b/internal/middlewares/oauth_middleware.go
@@ -137,7 +137,7 @@ func (oauth *Oauth) verify(ctx context.Context, session oauthSession) (map[strin
 	sources := oauth.claimsSources()
 
 	var idClaims, accessClaims, userInfoClaims map[string]interface{}
-	verified := false
+	idTokenVerified := false
 
 	// The ID token is the only token OIDC defines as an identity assertion, and
 	// its audience must be this client — otherwise a token minted for another
@@ -148,7 +148,7 @@ func (oauth *Oauth) verify(ctx context.Context, session oauthSession) (map[strin
 			return nil, fmt.Errorf("id token verification failed: %w", err)
 		}
 		idClaims = claims
-		verified = true
+		idTokenVerified = true
 	}
 
 	switch {
@@ -158,7 +158,6 @@ func (oauth *Oauth) verify(ctx context.Context, session oauthSession) (map[strin
 			return nil, fmt.Errorf("access token verification failed: %w", err)
 		}
 		accessClaims = claims
-		verified = true
 
 	case oauth.Endpoint.UserInfoURL != "":
 		// Opaque access tokens carry no verifiable claims; the provider's user
@@ -168,10 +167,11 @@ func (oauth *Oauth) verify(ctx context.Context, session oauthSession) (map[strin
 			return nil, fmt.Errorf("user info verification failed: %w", err)
 		}
 		userInfoClaims = claims
-		verified = true
 
 	default:
-		if !verified {
+		// Nothing could be verified: an opaque access token with no user info
+		// endpoint, and no ID token to fall back on.
+		if !idTokenVerified {
 			return nil, errNoVerifier
 		}
 	}
@@ -267,7 +267,7 @@ func wantsHTML(r *http.Request) bool {
 	if r.Header.Get("X-Requested-With") == "XMLHttpRequest" {
 		return false
 	}
-	return strings.Contains(r.Header.Get("Accept"), "text/html")
+	return strings.Contains(r.Header.Get("Accept"), contentTypeHTML)
 }
 
 // readOauthSession reads the session tokens from the request cookies.
@@ -314,7 +314,7 @@ func NewAuthCookie(r *http.Request, name, value, path string) *http.Cookie {
 		Value:    value,
 		Path:     path,
 		HttpOnly: true,
-		Secure:   scheme(r) == "https",
+		Secure:   scheme(r) == schemeHTTPS,
 		SameSite: http.SameSiteLaxMode,
 	}
 }

--- a/internal/middlewares/oauth_middleware.go
+++ b/internal/middlewares/oauth_middleware.go
@@ -19,16 +19,65 @@ package middlewares
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jkaninda/goma-gateway/util"
 	"golang.org/x/oauth2"
-	"net/http"
-	"time"
 )
 
-func (oauth Oauth) AuthMiddleware(next http.Handler) http.Handler {
+// Claim sources, in the order they may be listed in claimsSource.
+const (
+	ClaimSourceIDToken     = "id_token"
+	ClaimSourceUserInfo    = "userinfo"
+	ClaimSourceAccessToken = "access_token"
+)
+
+const (
+	// userInfoCacheTTL bounds how long a user info response is reused. It is
+	// also how long a token revoked at the provider keeps working when the
+	// provider issues opaque tokens, so it stays short.
+	userInfoCacheTTL = 60 * time.Second
+	// userInfoNegativeTTL caches rejections, so a flood of forged tokens cannot
+	// be amplified into a flood of requests against the identity provider.
+	userInfoNegativeTTL     = 10 * time.Second
+	userInfoRequestTimeout  = 10 * time.Second
+	maxUserInfoCacheEntries = 2048
+	// maxUserInfoBytes bounds the user info response we are willing to decode.
+	maxUserInfoBytes = 1 << 20
+)
+
+// DefaultClaimsSource lists claim sources in increasing order of precedence:
+// the ID token is the identity assertion OIDC defines, so it wins.
+var DefaultClaimsSource = []string{ClaimSourceAccessToken, ClaimSourceUserInfo, ClaimSourceIDToken}
+
+// errNoVerifier means the middleware has no way to establish that the session's
+// tokens are genuine. Sending the user back to the provider would only produce
+// another unverifiable token, so the request fails instead of looping.
+var errNoVerifier = errors.New("cannot verify the session: set endpoint.jwksUrl for JWT tokens, or endpoint.userInfoUrl for opaque ones")
+
+// oauthSession holds the tokens carried by the browser's cookies.
+type oauthSession struct {
+	accessToken  string
+	refreshToken string
+	idToken      string
+}
+
+func (oauth *Oauth) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		oauth.Forward.Strip(r)
+
 		// Skip paths that don’t match configured ones
 		if !isPathMatching(r.URL.Path, oauth.Path, oauth.Paths) {
 			next.ServeHTTP(w, r)
@@ -36,121 +85,391 @@ func (oauth Oauth) AuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		// Always skip the callback path
-		callbackPath := util.UrlParsePath(oauth.RedirectURL)
-		if r.URL.Path == callbackPath {
+		if r.URL.Path == util.UrlParsePath(oauth.RedirectURL) {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		oauthConf := oauth2Config(oauth)
-		authRedirectURL := oauthConf.AuthCodeURL(oauth.State)
-		ctx := context.Background()
-		jwksURL := oauth.Endpoint.JwksURL
-		// Retrieve tokens from cookies
-		accessTokenCookie, err := r.Cookie(GomaAccessToken)
-		refreshTokenCookie, _ := r.Cookie(GomaRefreshToken)
-		if err != nil {
-			http.Redirect(w, r, authRedirectURL, http.StatusTemporaryRedirect)
+		authRedirectURL := oauth2Config(oauth).AuthCodeURL(oauth.State)
+		ctx := r.Context()
+
+		session, ok := readOauthSession(r)
+		if !ok {
+			oauth.challenge(w, r, authRedirectURL, "no session cookie")
 			return
 		}
 
-		accessToken := accessTokenCookie.Value
-		refreshToken := ""
-		if refreshTokenCookie != nil {
-			refreshToken = refreshTokenCookie.Value
-		}
-
-		// Check token expiry (JWKS verification if URL is provided)
-		isExpired := tokenIsExpired(accessToken, jwksURL)
-		if isExpired {
-			logger.Info("Access token expired, attempting refresh...")
-
-			t := &oauth2.Token{
-				AccessToken:  accessToken,
-				RefreshToken: refreshToken,
-				Expiry:       time.Now().Add(-1 * time.Minute), // Simulate expiry
-			}
-
-			ts := oauthConf.TokenSource(ctx, t)
-			newToken, err := ts.Token()
-			if err != nil {
-				http.Redirect(w, r, authRedirectURL, http.StatusTemporaryRedirect)
+		claims, err := oauth.verify(ctx, session)
+		if err != nil {
+			if errors.Is(err, errNoVerifier) {
+				logger.Error("OAuth middleware is not configured to verify tokens, rejecting request",
+					"path", r.URL.Path, "error", err)
+				RespondWithError(w, r, http.StatusInternalServerError,
+					http.StatusText(http.StatusInternalServerError), oauth.Origins, getContentType(r))
 				return
 			}
+			logger.Debug("Access token rejected, attempting refresh", "path", r.URL.Path, "error", err)
 
-			http.SetCookie(w, &http.Cookie{
-				Name:     GomaAccessToken,
-				Value:    newToken.AccessToken,
-				Path:     oauth.CookiePath,
-				HttpOnly: true,
-			})
-
-			if newToken.RefreshToken != "" {
-				http.SetCookie(w, &http.Cookie{
-					Name:     GomaRefreshToken,
-					Value:    newToken.RefreshToken,
-					Path:     oauth.CookiePath,
-					HttpOnly: true,
-				})
+			refreshed, refreshErr := oauth.refresh(ctx, session)
+			if refreshErr != nil {
+				oauth.challenge(w, r, authRedirectURL, refreshErr.Error())
+				return
 			}
+			claims, err = oauth.verify(ctx, refreshed)
+			if err != nil {
+				oauth.challenge(w, r, authRedirectURL, err.Error())
+				return
+			}
+			writeOauthSession(w, r, oauth.CookiePath, refreshed)
+			session = refreshed
 		}
 
-		// Token valid or refreshed: continue
+		oauth.Forward.Apply(r, claims)
+		oauth.Forward.ForwardTokens(r, session.accessToken, session.idToken)
+
 		next.ServeHTTP(w, r)
 	})
 }
 
-// tokenIsExpired validates the JWT against the JWKS (if provided) and checks 'exp'.
-func tokenIsExpired(tokenStr, jwksURL string) bool {
-	var keyFunc jwt.Keyfunc
+// verify establishes that the session is genuine and returns the claims to
+// project upstream.
+func (oauth *Oauth) verify(ctx context.Context, session oauthSession) (map[string]interface{}, error) {
+	sources := oauth.claimsSources()
 
-	if jwksURL != "" {
-		// Use keyFunc that fetches public key from JWKS
-		keyFunc = func(token *jwt.Token) (interface{}, error) {
-			kid, ok := token.Header["kid"].(string)
-			if !ok {
-				return nil, errors.New("missing kid in token header")
-			}
+	var idClaims, accessClaims, userInfoClaims map[string]interface{}
+	verified := false
 
-			keySet, err := fetchJWKS(jwksURL)
-			if err != nil {
-				return nil, err
-			}
-
-			key, err := keySet.getKey(kid)
-			if err != nil {
-				return nil, err
-			}
-
-			return key, nil
-		}
-	} else {
-		// If no JWKS, parse without verifying signature
-		token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
+	// The ID token is the only token OIDC defines as an identity assertion, and
+	// its audience must be this client — otherwise a token minted for another
+	// application of the same provider would be accepted here.
+	if session.idToken != "" && oauth.Endpoint.JwksURL != "" {
+		claims, err := verifyJWT(session.idToken, oauth.Endpoint.JwksURL, oauth.Issuer, oauth.ClientID)
 		if err != nil {
-			return true
+			return nil, fmt.Errorf("id token verification failed: %w", err)
 		}
-		return isExpiredFromClaims(token.Claims)
+		idClaims = claims
+		verified = true
 	}
 
-	// Validate and parse the token
-	token, err := jwt.Parse(tokenStr, keyFunc)
-	if err != nil || !token.Valid {
-		return true
+	switch {
+	case oauth.Endpoint.JwksURL != "" && isJWT(session.accessToken):
+		claims, err := verifyJWT(session.accessToken, oauth.Endpoint.JwksURL, oauth.Issuer, oauth.Audience)
+		if err != nil {
+			return nil, fmt.Errorf("access token verification failed: %w", err)
+		}
+		accessClaims = claims
+		verified = true
+
+	case oauth.Endpoint.UserInfoURL != "":
+		// Opaque access tokens carry no verifiable claims; the provider's user
+		// info endpoint is what says whether the token is still valid.
+		claims, err := oauth.fetchUserInfo(ctx, session.accessToken)
+		if err != nil {
+			return nil, fmt.Errorf("user info verification failed: %w", err)
+		}
+		userInfoClaims = claims
+		verified = true
+
+	default:
+		if !verified {
+			return nil, errNoVerifier
+		}
 	}
 
-	return isExpiredFromClaims(token.Claims)
+	// User info was not needed to verify the session, but may still be the only
+	// place a claim we forward lives.
+	if userInfoClaims == nil && oauth.Endpoint.UserInfoURL != "" &&
+		slices.Contains(sources, ClaimSourceUserInfo) && oauth.Forward.Enabled() {
+		claims, err := oauth.fetchUserInfo(ctx, session.accessToken)
+		if err != nil {
+			logger.Warn("Failed to fetch user info, claims not forwarded from it", "error", err)
+		} else {
+			userInfoClaims = claims
+		}
+	}
+
+	claims := map[string]interface{}{}
+	for _, source := range sources {
+		switch source {
+		case ClaimSourceAccessToken:
+			claims = mergeClaims(claims, accessClaims)
+		case ClaimSourceUserInfo:
+			claims = mergeClaims(claims, userInfoClaims)
+		case ClaimSourceIDToken:
+			claims = mergeClaims(claims, idClaims)
+		}
+	}
+	return claimsFromMap(claims), nil
 }
 
-func isExpiredFromClaims(claims jwt.Claims) bool {
-	mapClaims, ok := claims.(jwt.MapClaims)
-	if !ok {
-		return true
+// refresh exchanges the refresh token for a new session.
+//
+// Each request refreshes on its own; with a provider that rotates refresh
+// tokens, concurrent requests can race. A shared session store removes that,
+// and is tracked separately.
+func (oauth *Oauth) refresh(ctx context.Context, session oauthSession) (oauthSession, error) {
+	if session.refreshToken == "" {
+		return session, errors.New("session expired and no refresh token is available")
 	}
-	expClaim, ok := mapClaims["exp"].(float64)
-	if !ok {
-		return true
+
+	source := oauth2Config(oauth).TokenSource(ctx, &oauth2.Token{
+		AccessToken:  session.accessToken,
+		RefreshToken: session.refreshToken,
+		Expiry:       time.Now().Add(-1 * time.Minute), // Force the exchange.
+	})
+	token, err := source.Token()
+	if err != nil {
+		return session, fmt.Errorf("token refresh failed: %w", err)
 	}
-	expTime := time.Unix(int64(expClaim), 0)
-	return time.Now().After(expTime)
+
+	refreshed := oauthSession{
+		accessToken:  token.AccessToken,
+		refreshToken: token.RefreshToken,
+		idToken:      session.idToken,
+	}
+	if refreshed.refreshToken == "" {
+		refreshed.refreshToken = session.refreshToken
+	}
+	if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
+		refreshed.idToken = idToken
+	}
+	return refreshed, nil
+}
+
+// challenge sends the caller to the identity provider, but only when the caller
+// is a browser navigating: an API client or an XHR needs a 401 it can act on,
+// not a redirect to a login page it cannot render.
+func (oauth *Oauth) challenge(w http.ResponseWriter, r *http.Request, authURL, reason string) {
+	logger.Debug("OAuth challenge", "path", r.URL.Path, "client_ip", RealIP(r), "reason", reason)
+
+	if r.Method == http.MethodGet && wantsHTML(r) {
+		http.Redirect(w, r, authURL, http.StatusFound)
+		return
+	}
+	w.Header().Set("WWW-Authenticate", `Bearer realm="oauth", error="invalid_token"`)
+	RespondWithError(w, r, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized),
+		oauth.Origins, getContentType(r))
+}
+
+func (oauth *Oauth) claimsSources() []string {
+	if len(oauth.ClaimsSource) == 0 {
+		return DefaultClaimsSource
+	}
+	return oauth.ClaimsSource
+}
+
+// wantsHTML reports whether the request is a browser navigation, the only case
+// where an authentication redirect makes sense.
+func wantsHTML(r *http.Request) bool {
+	if dest := r.Header.Get("Sec-Fetch-Dest"); dest != "" {
+		return dest == "document" || dest == "iframe" || dest == "frame"
+	}
+	if r.Header.Get("X-Requested-With") == "XMLHttpRequest" {
+		return false
+	}
+	return strings.Contains(r.Header.Get("Accept"), "text/html")
+}
+
+// readOauthSession reads the session tokens from the request cookies.
+func readOauthSession(r *http.Request) (oauthSession, bool) {
+	accessToken, err := r.Cookie(GomaAccessToken)
+	if err != nil || accessToken.Value == "" {
+		return oauthSession{}, false
+	}
+	session := oauthSession{accessToken: accessToken.Value}
+	if refreshToken, err := r.Cookie(GomaRefreshToken); err == nil {
+		session.refreshToken = refreshToken.Value
+	}
+	if idToken, err := r.Cookie(GomaIDToken); err == nil {
+		session.idToken = idToken.Value
+	}
+	return session, true
+}
+
+// writeOauthSession stores the session tokens as hardened cookies.
+func writeOauthSession(w http.ResponseWriter, r *http.Request, cookiePath string, session oauthSession) {
+	http.SetCookie(w, NewAuthCookie(r, GomaAccessToken, session.accessToken, cookiePath))
+	if session.refreshToken != "" {
+		http.SetCookie(w, NewAuthCookie(r, GomaRefreshToken, session.refreshToken, cookiePath))
+	}
+	if session.idToken != "" {
+		http.SetCookie(w, NewAuthCookie(r, GomaIDToken, session.idToken, cookiePath))
+	}
+}
+
+// NewAuthCookie builds a session cookie for the OAuth flow with the attributes
+// a browser needs to keep it safe: HttpOnly, SameSite=Lax so it survives the
+// provider's cross-site callback redirect without being sent on cross-site
+// POSTs, and Secure whenever the request arrived over TLS.
+//
+// The cookies are session cookies: the tokens they carry are only usable while
+// the provider still honours them, and a browser restart should not leave a
+// long-lived credential on disk.
+func NewAuthCookie(r *http.Request, name, value, path string) *http.Cookie {
+	if path == "" {
+		path = "/"
+	}
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     path,
+		HttpOnly: true,
+		Secure:   scheme(r) == "https",
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// verifyJWT validates a token's signature against the provider's JWKS and its
+// registered claims. Only asymmetric algorithms are accepted, so a token cannot
+// be forged by signing HS256 with a public key as the HMAC secret.
+func verifyJWT(tokenStr, jwksURL, issuer, audience string) (jwt.MapClaims, error) {
+	options := []jwt.ParserOption{
+		jwt.WithValidMethods(asymmetricAlgorithms),
+		jwt.WithExpirationRequired(),
+	}
+	if issuer != "" {
+		options = append(options, jwt.WithIssuer(issuer))
+	}
+	if audience != "" {
+		options = append(options, jwt.WithAudience(audience))
+	}
+
+	token, err := jwt.Parse(tokenStr, jwksKeyFunc(jwksURL), options...)
+	if err != nil {
+		return nil, err
+	}
+	if !token.Valid {
+		return nil, errors.New("token is not valid")
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("invalid claims format")
+	}
+	return claims, nil
+}
+
+func jwksKeyFunc(jwksURL string) jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, errors.New("missing kid in token header")
+		}
+		keySet, err := fetchJWKS(jwksURL)
+		if err != nil {
+			return nil, err
+		}
+		return keySet.getKey(kid)
+	}
+}
+
+// isJWT reports whether a token is a JWS the gateway could verify. Many
+// providers (Google, GitHub, Facebook) issue opaque access tokens instead.
+func isJWT(token string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	header, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var decoded struct {
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal(header, &decoded); err != nil {
+		return false
+	}
+	return decoded.Alg != ""
+}
+
+// userInfoStore caches user info lookups across routes and requests.
+var userInfoStore = &userInfoCache{entries: make(map[string]userInfoEntry)}
+
+type userInfoCache struct {
+	mu      sync.Mutex
+	entries map[string]userInfoEntry
+}
+
+type userInfoEntry struct {
+	claims    map[string]interface{}
+	err       error
+	expiresAt time.Time
+}
+
+func (c *userInfoCache) get(key string) (userInfoEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return userInfoEntry{}, false
+	}
+	return entry, true
+}
+
+func (c *userInfoCache) put(key string, entry userInfoEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) >= maxUserInfoCacheEntries {
+		now := time.Now()
+		for k, e := range c.entries {
+			if now.After(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		if len(c.entries) >= maxUserInfoCacheEntries {
+			c.entries = make(map[string]userInfoEntry)
+		}
+	}
+	c.entries[key] = entry
+}
+
+// fetchUserInfo calls the provider's user info endpoint with the access token.
+// A 2xx means the token is still valid and yields the user's claims; a 401 or
+// 403 means it is not.
+func (oauth *Oauth) fetchUserInfo(ctx context.Context, accessToken string) (map[string]interface{}, error) {
+	// Tokens are never used as cache keys directly.
+	sum := sha256.Sum256([]byte(oauth.Endpoint.UserInfoURL + "\x00" + accessToken))
+	key := hex.EncodeToString(sum[:])
+
+	if entry, ok := userInfoStore.get(key); ok {
+		return entry.claims, entry.err
+	}
+
+	claims, err := requestUserInfo(ctx, oauth.Endpoint.UserInfoURL, accessToken)
+	ttl := userInfoCacheTTL
+	if err != nil {
+		ttl = userInfoNegativeTTL
+	}
+	userInfoStore.put(key, userInfoEntry{claims: claims, err: err, expiresAt: time.Now().Add(ttl)})
+	return claims, err
+}
+
+func requestUserInfo(ctx context.Context, userInfoURL, accessToken string) (map[string]interface{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, userInfoRequestTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, userInfoURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Accept", "application/json")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("user info endpoint returned %d", response.StatusCode)
+	}
+
+	var claims map[string]interface{}
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxUserInfoBytes)).Decode(&claims); err != nil {
+		return nil, fmt.Errorf("failed to decode user info response: %w", err)
+	}
+	return claims, nil
 }

--- a/internal/middlewares/oauth_middleware_test.go
+++ b/internal/middlewares/oauth_middleware_test.go
@@ -33,14 +33,40 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+const (
+	testKeyID       = "test-key"
+	testClientID    = "goma"
+	testIssuer      = "https://idp.example.com"
+	testAuthURL     = "https://idp.example.com/authorize"
+	testRedirectURL = "https://example.com/callback"
+	testSubject     = "user-1"
+	testEmail       = "ada@example.com"
+	testGroup       = "admins"
+	testAttacker    = "attacker"
+	testGuardedPath = "/admin/*"
+
+	claimSub     = "sub"
+	claimExp     = "exp"
+	claimAud     = "aud"
+	headerUser   = "X-Auth-User"
+	headerEmail  = "X-Auth-Email"
+	headerGroup  = "X-Auth-Groups"
+	headerAccept = "Accept"
+	headerName   = "X-Auth-Name"
+	claimName    = "name"
+	claimEmail   = "email"
+	claimGroups  = "groups"
+	testTenant   = "acme"
+)
+
 // jwksServer serves a JWKS for key, so the middleware can verify tokens the
 // test signs with it.
-func jwksServer(t *testing.T, key *rsa.PrivateKey, kid string) *httptest.Server {
+func jwksServer(t *testing.T, key *rsa.PrivateKey) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(Jwks{Keys: []Jwk{{
-			Kid: kid,
+			Kid: testKeyID,
 			Kty: "RSA",
 			N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
 			E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
@@ -81,7 +107,7 @@ func nextRecorder(reached *bool, captured **http.Request) http.Handler {
 
 func browserRequest(path string, cookies ...*http.Cookie) *http.Request {
 	request := httptest.NewRequest(http.MethodGet, path, nil)
-	request.Header.Set("Accept", "text/html,application/xhtml+xml")
+	request.Header.Set(headerAccept, contentTypeHTML+",application/xhtml+xml")
 	for _, cookie := range cookies {
 		request.AddCookie(cookie)
 	}
@@ -92,21 +118,21 @@ func browserRequest(path string, cookies ...*http.Cookie) *http.Request {
 // future.
 func TestOauthRejectsForgedToken(t *testing.T) {
 	key := testRSAKey(t)
-	jwks := jwksServer(t, key, "test-key")
+	jwks := jwksServer(t, key)
 
 	attacker := testRSAKey(t)
-	forged := signToken(t, attacker, "test-key", jwt.MapClaims{
-		"sub": "attacker",
-		"exp": time.Now().Add(time.Hour).Unix(),
+	forged := signToken(t, attacker, testKeyID, jwt.MapClaims{
+		claimSub: testAttacker,
+		claimExp: time.Now().Add(time.Hour).Unix(),
 	})
 
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, JwksURL: jwks.URL},
 	}
 
 	reached := false
@@ -126,11 +152,11 @@ func TestOauthRejectsForgedToken(t *testing.T) {
 // An unsigned or alg=none token must not be accepted either.
 func TestOauthRejectsUnsignedToken(t *testing.T) {
 	key := testRSAKey(t)
-	jwks := jwksServer(t, key, "test-key")
+	jwks := jwksServer(t, key)
 
 	unsigned, err := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
-		"sub": "attacker",
-		"exp": time.Now().Add(time.Hour).Unix(),
+		claimSub: testAttacker,
+		claimExp: time.Now().Add(time.Hour).Unix(),
 	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
 	if err != nil {
 		t.Fatalf("failed to build unsigned token: %v", err)
@@ -139,10 +165,10 @@ func TestOauthRejectsUnsignedToken(t *testing.T) {
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, JwksURL: jwks.URL},
 	}
 
 	reached := false
@@ -158,31 +184,31 @@ func TestOauthRejectsUnsignedToken(t *testing.T) {
 
 func TestOauthAcceptsVerifiedTokenAndForwardsClaims(t *testing.T) {
 	key := testRSAKey(t)
-	jwks := jwksServer(t, key, "test-key")
+	jwks := jwksServer(t, key)
 
-	accessToken := signToken(t, key, "test-key", jwt.MapClaims{
-		"sub":    "user-1",
-		"email":  "ada@example.com",
-		"groups": []string{"admins"},
-		"iss":    "https://idp.example.com",
-		"aud":    "goma",
-		"exp":    time.Now().Add(time.Hour).Unix(),
+	accessToken := signToken(t, key, testKeyID, jwt.MapClaims{
+		"sub":      testSubject,
+		claimEmail: testEmail,
+		"groups":   []string{testGroup},
+		"iss":      testIssuer,
+		"aud":      testClientID,
+		claimExp:   time.Now().Add(time.Hour).Unix(),
 	})
 
 	oauth := &Oauth{
 		Path:         "/",
 		Paths:        []string{"/*"},
-		Provider:     "custom",
-		ClientID:     "goma",
-		Issuer:       "https://idp.example.com",
-		Audience:     "goma",
-		RedirectURL:  "https://example.com/callback",
-		Endpoint:     OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+		Provider:     ProviderCustom,
+		ClientID:     testClientID,
+		Issuer:       testIssuer,
+		Audience:     testClientID,
+		RedirectURL:  testRedirectURL,
+		Endpoint:     OauthEndpoint{AuthURL: testAuthURL, JwksURL: jwks.URL},
 		ClaimsSource: []string{ClaimSourceAccessToken},
 		Forward: &ClaimMapper{Headers: map[string]string{
-			"X-Auth-User":   "sub",
-			"X-Auth-Email":  "email",
-			"X-Auth-Groups": "groups",
+			headerUser:  claimSub,
+			headerEmail: claimEmail,
+			headerGroup: claimGroups,
 		}},
 	}
 
@@ -190,19 +216,19 @@ func TestOauthAcceptsVerifiedTokenAndForwardsClaims(t *testing.T) {
 	var upstream *http.Request
 	recorder := httptest.NewRecorder()
 	request := browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: accessToken})
-	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set(headerEmail, "attacker@example.com")
 	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
 
 	if !reached {
 		t.Fatalf("verified token did not reach the upstream, status = %d", recorder.Code)
 	}
-	if got := upstream.Header.Get("X-Auth-User"); got != "user-1" {
+	if got := upstream.Header.Get(headerUser); got != testSubject {
 		t.Errorf("X-Auth-User = %q, want user-1", got)
 	}
-	if got := upstream.Header.Get("X-Auth-Email"); got != "ada@example.com" {
+	if got := upstream.Header.Get(headerEmail); got != testEmail {
 		t.Errorf("X-Auth-Email = %q, want the verified claim, not the client's", got)
 	}
-	if got := upstream.Header.Get("X-Auth-Groups"); got != "admins" {
+	if got := upstream.Header.Get(headerGroup); got != testGroup {
 		t.Errorf("X-Auth-Groups = %q, want admins", got)
 	}
 }
@@ -210,24 +236,24 @@ func TestOauthAcceptsVerifiedTokenAndForwardsClaims(t *testing.T) {
 // A token minted for a different client of the same provider must not pass.
 func TestOauthEnforcesIssuerAndAudience(t *testing.T) {
 	key := testRSAKey(t)
-	jwks := jwksServer(t, key, "test-key")
+	jwks := jwksServer(t, key)
 
-	otherClient := signToken(t, key, "test-key", jwt.MapClaims{
-		"sub": "user-1",
-		"iss": "https://idp.example.com",
-		"aud": "another-app",
-		"exp": time.Now().Add(time.Hour).Unix(),
+	otherClient := signToken(t, key, testKeyID, jwt.MapClaims{
+		claimSub: testSubject,
+		"iss":    "https://idp.example.com",
+		claimAud: "another-app",
+		claimExp: time.Now().Add(time.Hour).Unix(),
 	})
 
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		Issuer:      "https://idp.example.com",
-		Audience:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		Issuer:      testIssuer,
+		Audience:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, JwksURL: jwks.URL},
 	}
 
 	reached := false
@@ -244,25 +270,25 @@ func TestOauthEnforcesIssuerAndAudience(t *testing.T) {
 // The ID token's audience is this client by definition, whatever the config says.
 func TestOauthEnforcesIDTokenAudience(t *testing.T) {
 	key := testRSAKey(t)
-	jwks := jwksServer(t, key, "test-key")
+	jwks := jwksServer(t, key)
 
-	idToken := signToken(t, key, "test-key", jwt.MapClaims{
-		"sub": "user-1",
-		"aud": "another-app",
-		"exp": time.Now().Add(time.Hour).Unix(),
+	idToken := signToken(t, key, testKeyID, jwt.MapClaims{
+		claimSub: testSubject,
+		claimAud: "another-app",
+		claimExp: time.Now().Add(time.Hour).Unix(),
 	})
-	accessToken := signToken(t, key, "test-key", jwt.MapClaims{
-		"sub": "user-1",
-		"exp": time.Now().Add(time.Hour).Unix(),
+	accessToken := signToken(t, key, testKeyID, jwt.MapClaims{
+		claimSub: testSubject,
+		claimExp: time.Now().Add(time.Hour).Unix(),
 	})
 
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, JwksURL: jwks.URL},
 	}
 
 	reached := false
@@ -296,11 +322,11 @@ func TestOauthVerifiesOpaqueTokenWithUserInfo(t *testing.T) {
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", UserInfoURL: userInfo.URL},
-		Forward:     &ClaimMapper{Headers: map[string]string{"X-Auth-Email": "email"}},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, UserInfoURL: userInfo.URL},
+		Forward:     &ClaimMapper{Headers: map[string]string{headerEmail: claimEmail}},
 	}
 
 	reached := false
@@ -312,7 +338,7 @@ func TestOauthVerifiesOpaqueTokenWithUserInfo(t *testing.T) {
 	if !reached {
 		t.Fatalf("valid opaque token did not reach the upstream, status = %d", recorder.Code)
 	}
-	if got := upstream.Header.Get("X-Auth-Email"); got != "ada@example.com" {
+	if got := upstream.Header.Get(headerEmail); got != testEmail {
 		t.Errorf("X-Auth-Email = %q, want ada@example.com", got)
 	}
 
@@ -332,10 +358,10 @@ func TestOauthFailsClosedWithoutVerifier(t *testing.T) {
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize"},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL},
 	}
 
 	reached := false
@@ -357,10 +383,10 @@ func TestOauthChallengeMatchesClientType(t *testing.T) {
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: "https://idp.example.com/jwks"},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, JwksURL: "https://idp.example.com/jwks"},
 	}
 
 	tests := []struct {
@@ -369,12 +395,12 @@ func TestOauthChallengeMatchesClientType(t *testing.T) {
 		method  string
 		want    int
 	}{
-		{"browser navigation", map[string]string{"Accept": "text/html", "Sec-Fetch-Dest": "document"}, http.MethodGet, http.StatusFound},
-		{"browser without fetch metadata", map[string]string{"Accept": "text/html"}, http.MethodGet, http.StatusFound},
-		{"fetch from a page", map[string]string{"Accept": "*/*", "Sec-Fetch-Dest": "empty"}, http.MethodGet, http.StatusUnauthorized},
+		{"browser navigation", map[string]string{headerAccept: contentTypeHTML, "Sec-Fetch-Dest": "document"}, http.MethodGet, http.StatusFound},
+		{"browser without fetch metadata", map[string]string{headerAccept: contentTypeHTML}, http.MethodGet, http.StatusFound},
+		{"fetch from a page", map[string]string{headerAccept: "*/*", "Sec-Fetch-Dest": "empty"}, http.MethodGet, http.StatusUnauthorized},
 		{"xhr", map[string]string{"X-Requested-With": "XMLHttpRequest"}, http.MethodGet, http.StatusUnauthorized},
-		{"json api", map[string]string{"Accept": "application/json"}, http.MethodGet, http.StatusUnauthorized},
-		{"form post", map[string]string{"Accept": "text/html"}, http.MethodPost, http.StatusUnauthorized},
+		{"json api", map[string]string{headerAccept: "application/json"}, http.MethodGet, http.StatusUnauthorized},
+		{"form post", map[string]string{headerAccept: contentTypeHTML}, http.MethodPost, http.StatusUnauthorized},
 	}
 
 	for _, test := range tests {
@@ -403,10 +429,10 @@ func TestOauthSkipsCallbackPath(t *testing.T) {
 	oauth := &Oauth{
 		Path:        "/",
 		Paths:       []string{"/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
 		RedirectURL: "https://example.com/callback/protected",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: "https://idp.example.com/jwks"},
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, JwksURL: "https://idp.example.com/jwks"},
 	}
 
 	reached := false
@@ -425,17 +451,17 @@ func TestOauthSkipsCallbackPath(t *testing.T) {
 func TestOauthStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
 	oauth := &Oauth{
 		Path:        "/",
-		Paths:       []string{"/admin/*"},
-		Provider:    "custom",
-		ClientID:    "goma",
-		RedirectURL: "https://example.com/callback",
-		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", UserInfoURL: "https://idp.example.com/userinfo"},
-		Forward:     &ClaimMapper{Headers: map[string]string{"X-Auth-Email": "email"}},
+		Paths:       []string{testGuardedPath},
+		Provider:    ProviderCustom,
+		ClientID:    testClientID,
+		RedirectURL: testRedirectURL,
+		Endpoint:    OauthEndpoint{AuthURL: testAuthURL, UserInfoURL: "https://idp.example.com/userinfo"},
+		Forward:     &ClaimMapper{Headers: map[string]string{headerEmail: claimEmail}},
 	}
 
 	// A path the middleware does not guard, so the request is proxied as is.
 	request := browserRequest("/public")
-	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set(headerEmail, "attacker@example.com")
 
 	recorder := httptest.NewRecorder()
 	reached := false
@@ -445,16 +471,16 @@ func TestOauthStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
 	if !reached {
 		t.Fatalf("unguarded path was blocked, status = %d", recorder.Code)
 	}
-	if got := upstream.Header.Get("X-Auth-Email"); got != "" {
+	if got := upstream.Header.Get(headerEmail); got != "" {
 		t.Errorf("X-Auth-Email = %q, want the client value stripped", got)
 	}
 
 	// And on the guarded path, where the request never reaches the upstream.
 	request = browserRequest("/admin/settings")
-	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set(headerEmail, "attacker@example.com")
 	recorder = httptest.NewRecorder()
 	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
-	if got := request.Header.Get("X-Auth-Email"); got != "" {
+	if got := request.Header.Get(headerEmail); got != "" {
 		t.Errorf("X-Auth-Email = %q, want the client value stripped", got)
 	}
 }
@@ -463,13 +489,13 @@ func TestOauthStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
 func TestJwtStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
 	jwtAuth := &JwtAuth{
 		Path:    "/",
-		Paths:   []string{"/admin/*"},
+		Paths:   []string{testGuardedPath},
 		Secret:  "test-secret",
-		Forward: &ClaimMapper{Headers: map[string]string{"X-Auth-Email": "email"}},
+		Forward: &ClaimMapper{Headers: map[string]string{headerEmail: claimEmail}},
 	}
 
 	request := httptest.NewRequest(http.MethodGet, "/public", nil)
-	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	request.Header.Set(headerEmail, "attacker@example.com")
 
 	reached := false
 	var upstream *http.Request
@@ -479,14 +505,14 @@ func TestJwtStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
 	if !reached {
 		t.Fatalf("unguarded path was blocked, status = %d", recorder.Code)
 	}
-	if got := upstream.Header.Get("X-Auth-Email"); got != "" {
+	if got := upstream.Header.Get(headerEmail); got != "" {
 		t.Errorf("X-Auth-Email = %q, want the client value stripped", got)
 	}
 }
 
 func TestIsJWT(t *testing.T) {
 	key := testRSAKey(t)
-	signed := signToken(t, key, "kid", jwt.MapClaims{"sub": "user-1"})
+	signed := signToken(t, key, "kid", jwt.MapClaims{claimSub: testSubject})
 
 	if !isJWT(signed) {
 		t.Error("isJWT(signed token) = false, want true")

--- a/internal/middlewares/oauth_middleware_test.go
+++ b/internal/middlewares/oauth_middleware_test.go
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2024 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package middlewares
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// jwksServer serves a JWKS for key, so the middleware can verify tokens the
+// test signs with it.
+func jwksServer(t *testing.T, key *rsa.PrivateKey, kid string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Jwks{Keys: []Jwk{{
+			Kid: kid,
+			Kty: "RSA",
+			N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+			E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+		}}})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func signToken(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return signed
+}
+
+func testRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	return key
+}
+
+// nextRecorder reports whether the request reached the upstream, and captures it.
+func nextRecorder(reached *bool, captured **http.Request) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		*captured = r
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func browserRequest(path string, cookies ...*http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	request.Header.Set("Accept", "text/html,application/xhtml+xml")
+	for _, cookie := range cookies {
+		request.AddCookie(cookie)
+	}
+	return request
+}
+
+// A token nobody signed must not be accepted just because its "exp" is in the
+// future.
+func TestOauthRejectsForgedToken(t *testing.T) {
+	key := testRSAKey(t)
+	jwks := jwksServer(t, key, "test-key")
+
+	attacker := testRSAKey(t)
+	forged := signToken(t, attacker, "test-key", jwt.MapClaims{
+		"sub": "attacker",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: forged}))
+
+	if reached {
+		t.Fatal("forged token reached the upstream")
+	}
+	if recorder.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d (redirect to the provider)", recorder.Code, http.StatusFound)
+	}
+}
+
+// An unsigned or alg=none token must not be accepted either.
+func TestOauthRejectsUnsignedToken(t *testing.T) {
+	key := testRSAKey(t)
+	jwks := jwksServer(t, key, "test-key")
+
+	unsigned, err := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"sub": "attacker",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("failed to build unsigned token: %v", err)
+	}
+
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: unsigned}))
+
+	if reached {
+		t.Fatal("unsigned token reached the upstream")
+	}
+}
+
+func TestOauthAcceptsVerifiedTokenAndForwardsClaims(t *testing.T) {
+	key := testRSAKey(t)
+	jwks := jwksServer(t, key, "test-key")
+
+	accessToken := signToken(t, key, "test-key", jwt.MapClaims{
+		"sub":    "user-1",
+		"email":  "ada@example.com",
+		"groups": []string{"admins"},
+		"iss":    "https://idp.example.com",
+		"aud":    "goma",
+		"exp":    time.Now().Add(time.Hour).Unix(),
+	})
+
+	oauth := &Oauth{
+		Path:         "/",
+		Paths:        []string{"/*"},
+		Provider:     "custom",
+		ClientID:     "goma",
+		Issuer:       "https://idp.example.com",
+		Audience:     "goma",
+		RedirectURL:  "https://example.com/callback",
+		Endpoint:     OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+		ClaimsSource: []string{ClaimSourceAccessToken},
+		Forward: &ClaimMapper{Headers: map[string]string{
+			"X-Auth-User":   "sub",
+			"X-Auth-Email":  "email",
+			"X-Auth-Groups": "groups",
+		}},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	request := browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: accessToken})
+	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
+
+	if !reached {
+		t.Fatalf("verified token did not reach the upstream, status = %d", recorder.Code)
+	}
+	if got := upstream.Header.Get("X-Auth-User"); got != "user-1" {
+		t.Errorf("X-Auth-User = %q, want user-1", got)
+	}
+	if got := upstream.Header.Get("X-Auth-Email"); got != "ada@example.com" {
+		t.Errorf("X-Auth-Email = %q, want the verified claim, not the client's", got)
+	}
+	if got := upstream.Header.Get("X-Auth-Groups"); got != "admins" {
+		t.Errorf("X-Auth-Groups = %q, want admins", got)
+	}
+}
+
+// A token minted for a different client of the same provider must not pass.
+func TestOauthEnforcesIssuerAndAudience(t *testing.T) {
+	key := testRSAKey(t)
+	jwks := jwksServer(t, key, "test-key")
+
+	otherClient := signToken(t, key, "test-key", jwt.MapClaims{
+		"sub": "user-1",
+		"iss": "https://idp.example.com",
+		"aud": "another-app",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		Issuer:      "https://idp.example.com",
+		Audience:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: otherClient}))
+
+	if reached {
+		t.Fatal("token issued to another client reached the upstream")
+	}
+}
+
+// The ID token's audience is this client by definition, whatever the config says.
+func TestOauthEnforcesIDTokenAudience(t *testing.T) {
+	key := testRSAKey(t)
+	jwks := jwksServer(t, key, "test-key")
+
+	idToken := signToken(t, key, "test-key", jwt.MapClaims{
+		"sub": "user-1",
+		"aud": "another-app",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	accessToken := signToken(t, key, "test-key", jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: jwks.URL},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected",
+			&http.Cookie{Name: GomaAccessToken, Value: accessToken},
+			&http.Cookie{Name: GomaIDToken, Value: idToken}))
+
+	if reached {
+		t.Fatal("ID token issued to another client reached the upstream")
+	}
+}
+
+// Opaque access tokens (Google, GitHub, Facebook) are validated by asking the
+// provider's user info endpoint, which also supplies the claims to forward.
+func TestOauthVerifiesOpaqueTokenWithUserInfo(t *testing.T) {
+	var seenAuthorization string
+	userInfo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuthorization = r.Header.Get("Authorization")
+		if seenAuthorization != "Bearer opaque-valid-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"sub":"user-1","email":"ada@example.com"}`)
+	}))
+	defer userInfo.Close()
+
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", UserInfoURL: userInfo.URL},
+		Forward:     &ClaimMapper{Headers: map[string]string{"X-Auth-Email": "email"}},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: "opaque-valid-token"}))
+
+	if !reached {
+		t.Fatalf("valid opaque token did not reach the upstream, status = %d", recorder.Code)
+	}
+	if got := upstream.Header.Get("X-Auth-Email"); got != "ada@example.com" {
+		t.Errorf("X-Auth-Email = %q, want ada@example.com", got)
+	}
+
+	// And a token the provider rejects must not pass.
+	reached = false
+	recorder = httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: "opaque-forged-token"}))
+	if reached {
+		t.Fatal("token rejected by the provider reached the upstream")
+	}
+}
+
+// Nothing to verify against means the route is not guarded at all, so the
+// request fails instead of being waved through.
+func TestOauthFailsClosedWithoutVerifier(t *testing.T) {
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize"},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/protected", &http.Cookie{Name: GomaAccessToken, Value: "anything"}))
+
+	if reached {
+		t.Fatal("unverifiable token reached the upstream")
+	}
+	if recorder.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+}
+
+// An API client cannot render a login page: it needs a 401 it can act on.
+func TestOauthChallengeMatchesClientType(t *testing.T) {
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: "https://idp.example.com/jwks"},
+	}
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		method  string
+		want    int
+	}{
+		{"browser navigation", map[string]string{"Accept": "text/html", "Sec-Fetch-Dest": "document"}, http.MethodGet, http.StatusFound},
+		{"browser without fetch metadata", map[string]string{"Accept": "text/html"}, http.MethodGet, http.StatusFound},
+		{"fetch from a page", map[string]string{"Accept": "*/*", "Sec-Fetch-Dest": "empty"}, http.MethodGet, http.StatusUnauthorized},
+		{"xhr", map[string]string{"X-Requested-With": "XMLHttpRequest"}, http.MethodGet, http.StatusUnauthorized},
+		{"json api", map[string]string{"Accept": "application/json"}, http.MethodGet, http.StatusUnauthorized},
+		{"form post", map[string]string{"Accept": "text/html"}, http.MethodPost, http.StatusUnauthorized},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, "/protected", nil)
+			for name, value := range test.headers {
+				request.Header.Set(name, value)
+			}
+			recorder := httptest.NewRecorder()
+			reached := false
+			var upstream *http.Request
+			oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
+
+			if reached {
+				t.Fatal("request without a session reached the upstream")
+			}
+			if recorder.Code != test.want {
+				t.Errorf("status = %d, want %d", recorder.Code, test.want)
+			}
+		})
+	}
+}
+
+// The callback must stay reachable, otherwise login cannot complete.
+func TestOauthSkipsCallbackPath(t *testing.T) {
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback/protected",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", JwksURL: "https://idp.example.com/jwks"},
+	}
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder,
+		browserRequest("/callback/protected?code=abc&state=xyz"))
+
+	if !reached {
+		t.Fatalf("callback path was blocked, status = %d", recorder.Code)
+	}
+}
+
+// Even on the paths it does not guard, the middleware must not let a client
+// supply the identity headers the upstream trusts.
+func TestOauthStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
+	oauth := &Oauth{
+		Path:        "/",
+		Paths:       []string{"/admin/*"},
+		Provider:    "custom",
+		ClientID:    "goma",
+		RedirectURL: "https://example.com/callback",
+		Endpoint:    OauthEndpoint{AuthURL: "https://idp.example.com/authorize", UserInfoURL: "https://idp.example.com/userinfo"},
+		Forward:     &ClaimMapper{Headers: map[string]string{"X-Auth-Email": "email"}},
+	}
+
+	// A path the middleware does not guard, so the request is proxied as is.
+	request := browserRequest("/public")
+	request.Header.Set("X-Auth-Email", "attacker@example.com")
+
+	recorder := httptest.NewRecorder()
+	reached := false
+	var upstream *http.Request
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
+
+	if !reached {
+		t.Fatalf("unguarded path was blocked, status = %d", recorder.Code)
+	}
+	if got := upstream.Header.Get("X-Auth-Email"); got != "" {
+		t.Errorf("X-Auth-Email = %q, want the client value stripped", got)
+	}
+
+	// And on the guarded path, where the request never reaches the upstream.
+	request = browserRequest("/admin/settings")
+	request.Header.Set("X-Auth-Email", "attacker@example.com")
+	recorder = httptest.NewRecorder()
+	oauth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
+	if got := request.Header.Get("X-Auth-Email"); got != "" {
+		t.Errorf("X-Auth-Email = %q, want the client value stripped", got)
+	}
+}
+
+// The JWT middleware owns the same keys and must strip them the same way.
+func TestJwtStripsIdentityHeadersOnUnguardedPaths(t *testing.T) {
+	jwtAuth := &JwtAuth{
+		Path:    "/",
+		Paths:   []string{"/admin/*"},
+		Secret:  "test-secret",
+		Forward: &ClaimMapper{Headers: map[string]string{"X-Auth-Email": "email"}},
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/public", nil)
+	request.Header.Set("X-Auth-Email", "attacker@example.com")
+
+	reached := false
+	var upstream *http.Request
+	recorder := httptest.NewRecorder()
+	jwtAuth.AuthMiddleware(nextRecorder(&reached, &upstream)).ServeHTTP(recorder, request)
+
+	if !reached {
+		t.Fatalf("unguarded path was blocked, status = %d", recorder.Code)
+	}
+	if got := upstream.Header.Get("X-Auth-Email"); got != "" {
+		t.Errorf("X-Auth-Email = %q, want the client value stripped", got)
+	}
+}
+
+func TestIsJWT(t *testing.T) {
+	key := testRSAKey(t)
+	signed := signToken(t, key, "kid", jwt.MapClaims{"sub": "user-1"})
+
+	if !isJWT(signed) {
+		t.Error("isJWT(signed token) = false, want true")
+	}
+	for _, opaque := range []string{"", "ya29.a0AfH6SMB", "a.b", strings.Repeat("x", 40), "not.a.jwt"} {
+		if isJWT(opaque) {
+			t.Errorf("isJWT(%q) = true, want false", opaque)
+		}
+	}
+}
+
+func TestNewAuthCookie(t *testing.T) {
+	secure := httptest.NewRequest(http.MethodGet, "https://example.com/protected", nil)
+	cookie := NewAuthCookie(secure, GomaAccessToken, "token", "/app")
+
+	if !cookie.HttpOnly {
+		t.Error("cookie is not HttpOnly")
+	}
+	if !cookie.Secure {
+		t.Error("cookie served over TLS is not Secure")
+	}
+	if cookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("SameSite = %v, want Lax", cookie.SameSite)
+	}
+	if cookie.Path != "/app" {
+		t.Errorf("Path = %q, want /app", cookie.Path)
+	}
+
+	plain := httptest.NewRequest(http.MethodGet, "http://example.com/protected", nil)
+	if NewAuthCookie(plain, GomaAccessToken, "token", "").Secure {
+		t.Error("cookie served over plain HTTP is marked Secure, browsers would drop it")
+	}
+	if got := NewAuthCookie(plain, GomaAccessToken, "token", "").Path; got != "/" {
+		t.Errorf("Path = %q, want / by default", got)
+	}
+}

--- a/internal/middlewares/types.go
+++ b/internal/middlewares/types.go
@@ -98,9 +98,10 @@ type JwtAuth struct {
 	JwksUrl              string
 	RsaKey               *rsa.PublicKey
 	ClaimsExpression     string
-	ForwardHeaders       map[string]string
 	ForwardAuthorization bool
-	parsedExpression     Expression
+	// Forward projects verified claims onto the upstream request.
+	Forward          *ClaimMapper
+	parsedExpression Expression
 }
 
 // AuthenticationMiddleware Define struct
@@ -166,6 +167,15 @@ type Oauth struct {
 	Origins    []string
 	CookiePath string
 	Provider   string
+	// Issuer and Audience, when set, are enforced on JWT access tokens. The ID
+	// token's audience is always checked against ClientID, as OIDC requires.
+	Issuer   string
+	Audience string
+	// ClaimsSource lists where user claims are read from, in increasing order of
+	// precedence. Defaults to DefaultClaimsSource.
+	ClaimsSource []string
+	// Forward projects the authenticated user's claims onto the upstream request.
+	Forward *ClaimMapper
 }
 type OauthEndpoint struct {
 	AuthURL     string

--- a/internal/middlewares/var.go
+++ b/internal/middlewares/var.go
@@ -30,6 +30,7 @@ const (
 	GomaAccessToken            = "goma_access_token"
 	GomaRefreshToken           = "goma_refresh_token"
 	GomaIDToken                = "goma_id_token"
+	contentTypeHTML            = "text/html"
 	constGomaCacheHeader       = "X-Goma-Cache"
 	constGomaCacheMaxAgeHeader = "X-Goma-Cache-Max-Age"
 )

--- a/internal/middlewares/var.go
+++ b/internal/middlewares/var.go
@@ -18,16 +18,18 @@
 package middlewares
 
 import (
+	"regexp"
+
 	"github.com/go-redis/redis_rate/v10"
 	"github.com/jkaninda/goma-gateway/internal/config"
 	logger2 "github.com/jkaninda/logger"
 	"github.com/redis/go-redis/v9"
-	"regexp"
 )
 
 const (
 	GomaAccessToken            = "goma_access_token"
 	GomaRefreshToken           = "goma_refresh_token"
+	GomaIDToken                = "goma_id_token"
 	constGomaCacheHeader       = "X-Goma-Cache"
 	constGomaCacheMaxAgeHeader = "X-Goma-Cache-Max-Age"
 )

--- a/internal/oauth_config_test.go
+++ b/internal/oauth_config_test.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+import (
+	"testing"
+
+	goutils "github.com/jkaninda/go-utils"
+	"gopkg.in/yaml.v3"
+)
+
+// decodeOauthRule walks the same path the gateway takes at load time: YAML into
+// a generic rule, then a deep copy into the typed rule.
+func decodeOauthRule(t *testing.T, source string) *OauthRulerMiddleware {
+	t.Helper()
+	middleware := &Middleware{}
+	if err := yaml.Unmarshal([]byte(source), middleware); err != nil {
+		t.Fatalf("failed to decode middleware: %v", err)
+	}
+	rule := &OauthRulerMiddleware{}
+	if err := goutils.DeepCopy(rule, middleware.Rule); err != nil {
+		t.Fatalf("failed to copy rule: %v", err)
+	}
+	return rule
+}
+
+func TestOauthRuleForwardDecoding(t *testing.T) {
+	rule := decodeOauthRule(t, `
+name: sso
+type: oauth
+paths: ["/*"]
+rule:
+  clientId: goma
+  clientSecret: secret
+  provider: custom
+  redirectUrl: https://example.com/callback
+  endpoint:
+    authUrl: https://idp.example.com/authorize
+    tokenUrl: https://idp.example.com/token
+    jwksUrl: https://idp.example.com/jwks
+  issuer: https://idp.example.com
+  audience: goma
+  claimsSource: [id_token, userinfo]
+  forward:
+    stripInbound: true
+    arraySeparator: "|"
+    encoding: raw
+    maxValueBytes: 2048
+    accessTokenHeader: Authorization
+    idTokenHeader: X-Auth-Id-Token
+    headers:
+      X-Auth-User: sub
+      X-Auth-Name: "{{ .given_name }} {{ .family_name }}"
+    query:
+      uid: sub
+    cookies:
+      app_user: email
+`)
+
+	if err := rule.validate(); err != nil {
+		t.Fatalf("validate() = %v, want nil", err)
+	}
+	if rule.Issuer != "https://idp.example.com" || rule.Audience != "goma" {
+		t.Errorf("issuer/audience = %q/%q, want the configured values", rule.Issuer, rule.Audience)
+	}
+	if len(rule.ClaimsSource) != 2 {
+		t.Fatalf("claimsSource = %v, want two entries", rule.ClaimsSource)
+	}
+
+	mapper := claimMapper(rule.Forward, nil)
+	if mapper == nil {
+		t.Fatal("claimMapper() = nil, want a mapper")
+	}
+	if got := mapper.Headers["X-Auth-Name"]; got != "{{ .given_name }} {{ .family_name }}" {
+		t.Errorf("X-Auth-Name mapping = %q, want the template", got)
+	}
+	if got := mapper.Query["uid"]; got != "sub" {
+		t.Errorf("uid mapping = %q, want sub", got)
+	}
+	if got := mapper.Cookies["app_user"]; got != "email" {
+		t.Errorf("app_user mapping = %q, want email", got)
+	}
+	if mapper.ArraySeparator != "|" || mapper.Encoding != "raw" || mapper.MaxValueBytes != 2048 {
+		t.Errorf("mapper options = %q/%q/%d, want |/raw/2048",
+			mapper.ArraySeparator, mapper.Encoding, mapper.MaxValueBytes)
+	}
+	if mapper.AccessTokenHeader != "Authorization" || mapper.IDTokenHeader != "X-Auth-Id-Token" {
+		t.Errorf("token headers = %q/%q, want Authorization/X-Auth-Id-Token",
+			mapper.AccessTokenHeader, mapper.IDTokenHeader)
+	}
+	if mapper.StripInbound == nil || !*mapper.StripInbound {
+		t.Error("stripInbound did not survive decoding")
+	}
+}
+
+// A route the gateway cannot verify tokens for must not load at all.
+func TestOauthRuleRequiresVerifier(t *testing.T) {
+	rule := decodeOauthRule(t, `
+name: sso
+type: oauth
+paths: ["/*"]
+rule:
+  clientId: goma
+  clientSecret: secret
+  provider: custom
+  redirectUrl: https://example.com/callback
+  endpoint:
+    authUrl: https://idp.example.com/authorize
+    tokenUrl: https://idp.example.com/token
+`)
+	if err := rule.validate(); err == nil {
+		t.Error("validate() = nil, want an error for a rule with no jwksUrl and no userInfoUrl")
+	}
+}
+
+// Known providers do not need their endpoints spelled out.
+func TestOauthRuleProviderDefaults(t *testing.T) {
+	for provider, wantUserInfo := range map[string]string{
+		"google":   "https://www.googleapis.com/oauth2/v2/userinfo",
+		"github":   "https://api.github.com/user",
+		"gitlab":   "https://gitlab.com/oauth/userinfo",
+		"amazon":   "https://api.amazon.com/user/profile",
+		"facebook": "https://graph.facebook.com/me?fields=id,name,email",
+	} {
+		t.Run(provider, func(t *testing.T) {
+			rule := &OauthRulerMiddleware{
+				ClientID:     "goma",
+				ClientSecret: "secret",
+				RedirectURL:  "https://example.com/callback",
+				Provider:     provider,
+			}
+			if err := rule.validate(); err != nil {
+				t.Fatalf("validate() = %v, want nil", err)
+			}
+			if rule.Endpoint.UserInfoURL != wantUserInfo {
+				t.Errorf("userInfoUrl = %q, want %q", rule.Endpoint.UserInfoURL, wantUserInfo)
+			}
+		})
+	}
+}
+
+func TestOauthRuleRejectsUnknownClaimsSource(t *testing.T) {
+	rule := &OauthRulerMiddleware{
+		ClientID:     "goma",
+		ClientSecret: "secret",
+		RedirectURL:  "https://example.com/callback",
+		Provider:     "google",
+		ClaimsSource: []string{"refresh_token"},
+	}
+	if err := rule.validate(); err == nil {
+		t.Error("validate() = nil, want an error for an unknown claimsSource")
+	}
+}
+
+// The deprecated flat map keeps working, and the nested block wins per key.
+func TestJwtForwardHeadersBackwardCompatible(t *testing.T) {
+	legacy := map[string]string{"X-User-ID": "sub", "X-User-Email": "email"}
+
+	mapper := claimMapper(nil, legacy)
+	if mapper == nil || mapper.Headers["X-User-ID"] != "sub" {
+		t.Fatalf("claimMapper(legacy only) = %v, want the legacy headers", mapper)
+	}
+
+	mapper = claimMapper(&ForwardClaimsRule{
+		Headers: map[string]string{"X-User-Email": "mail", "X-User-Name": "name"},
+	}, legacy)
+	if got := mapper.Headers["X-User-ID"]; got != "sub" {
+		t.Errorf("X-User-ID = %q, want the legacy mapping preserved", got)
+	}
+	if got := mapper.Headers["X-User-Email"]; got != "mail" {
+		t.Errorf("X-User-Email = %q, want the nested block to win", got)
+	}
+	if got := mapper.Headers["X-User-Name"]; got != "name" {
+		t.Errorf("X-User-Name = %q, want the nested mapping", got)
+	}
+	if legacy["X-User-Email"] != "email" {
+		t.Error("the legacy map was mutated")
+	}
+
+	if claimMapper(nil, nil) != nil {
+		t.Error("claimMapper(nothing configured) != nil, want nil so the mapper stays inert")
+	}
+}

--- a/internal/oauth_config_test.go
+++ b/internal/oauth_config_test.go
@@ -21,7 +21,14 @@ import (
 	"testing"
 
 	goutils "github.com/jkaninda/go-utils"
+	"github.com/jkaninda/goma-gateway/internal/middlewares"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	testClientID = "goma"
+	claimSub     = "sub"
+	claimEmail   = "email"
 )
 
 // decodeOauthRule walks the same path the gateway takes at load time: YAML into
@@ -75,7 +82,7 @@ rule:
 	if err := rule.validate(); err != nil {
 		t.Fatalf("validate() = %v, want nil", err)
 	}
-	if rule.Issuer != "https://idp.example.com" || rule.Audience != "goma" {
+	if rule.Issuer != "https://idp.example.com" || rule.Audience != testClientID {
 		t.Errorf("issuer/audience = %q/%q, want the configured values", rule.Issuer, rule.Audience)
 	}
 	if len(rule.ClaimsSource) != 2 {
@@ -89,10 +96,10 @@ rule:
 	if got := mapper.Headers["X-Auth-Name"]; got != "{{ .given_name }} {{ .family_name }}" {
 		t.Errorf("X-Auth-Name mapping = %q, want the template", got)
 	}
-	if got := mapper.Query["uid"]; got != "sub" {
+	if got := mapper.Query["uid"]; got != claimSub {
 		t.Errorf("uid mapping = %q, want sub", got)
 	}
-	if got := mapper.Cookies["app_user"]; got != "email" {
+	if got := mapper.Cookies["app_user"]; got != claimEmail {
 		t.Errorf("app_user mapping = %q, want email", got)
 	}
 	if mapper.ArraySeparator != "|" || mapper.Encoding != "raw" || mapper.MaxValueBytes != 2048 {
@@ -131,15 +138,15 @@ rule:
 // Known providers do not need their endpoints spelled out.
 func TestOauthRuleProviderDefaults(t *testing.T) {
 	for provider, wantUserInfo := range map[string]string{
-		"google":   "https://www.googleapis.com/oauth2/v2/userinfo",
-		"github":   "https://api.github.com/user",
-		"gitlab":   "https://gitlab.com/oauth/userinfo",
-		"amazon":   "https://api.amazon.com/user/profile",
-		"facebook": "https://graph.facebook.com/me?fields=id,name,email",
+		middlewares.ProviderGoogle:   "https://www.googleapis.com/oauth2/v2/userinfo",
+		middlewares.ProviderGitHub:   "https://api.github.com/user",
+		middlewares.ProviderGitLab:   "https://gitlab.com/oauth/userinfo",
+		middlewares.ProviderAmazon:   "https://api.amazon.com/user/profile",
+		middlewares.ProviderFacebook: "https://graph.facebook.com/me?fields=id,name,email",
 	} {
 		t.Run(provider, func(t *testing.T) {
 			rule := &OauthRulerMiddleware{
-				ClientID:     "goma",
+				ClientID:     testClientID,
 				ClientSecret: "secret",
 				RedirectURL:  "https://example.com/callback",
 				Provider:     provider,
@@ -156,10 +163,10 @@ func TestOauthRuleProviderDefaults(t *testing.T) {
 
 func TestOauthRuleRejectsUnknownClaimsSource(t *testing.T) {
 	rule := &OauthRulerMiddleware{
-		ClientID:     "goma",
+		ClientID:     testClientID,
 		ClientSecret: "secret",
 		RedirectURL:  "https://example.com/callback",
-		Provider:     "google",
+		Provider:     middlewares.ProviderGoogle,
 		ClaimsSource: []string{"refresh_token"},
 	}
 	if err := rule.validate(); err == nil {
@@ -169,17 +176,17 @@ func TestOauthRuleRejectsUnknownClaimsSource(t *testing.T) {
 
 // The deprecated flat map keeps working, and the nested block wins per key.
 func TestJwtForwardHeadersBackwardCompatible(t *testing.T) {
-	legacy := map[string]string{"X-User-ID": "sub", "X-User-Email": "email"}
+	legacy := map[string]string{"X-User-ID": claimSub, "X-User-Email": claimEmail}
 
 	mapper := claimMapper(nil, legacy)
-	if mapper == nil || mapper.Headers["X-User-ID"] != "sub" {
+	if mapper == nil || mapper.Headers["X-User-ID"] != claimSub {
 		t.Fatalf("claimMapper(legacy only) = %v, want the legacy headers", mapper)
 	}
 
 	mapper = claimMapper(&ForwardClaimsRule{
 		Headers: map[string]string{"X-User-Email": "mail", "X-User-Name": "name"},
 	}, legacy)
-	if got := mapper.Headers["X-User-ID"]; got != "sub" {
+	if got := mapper.Headers["X-User-ID"]; got != claimSub {
 		t.Errorf("X-User-ID = %q, want the legacy mapping preserved", got)
 	}
 	if got := mapper.Headers["X-User-Email"]; got != "mail" {
@@ -188,7 +195,7 @@ func TestJwtForwardHeadersBackwardCompatible(t *testing.T) {
 	if got := mapper.Headers["X-User-Name"]; got != "name" {
 		t.Errorf("X-User-Name = %q, want the nested mapping", got)
 	}
-	if legacy["X-User-Email"] != "email" {
+	if legacy["X-User-Email"] != claimEmail {
 		t.Error("the legacy map was mutated")
 	}
 

--- a/internal/types.go
+++ b/internal/types.go
@@ -148,16 +148,52 @@ type JWTRuleMiddleware struct {
 	// Algorithms is the list of accepted JWT signing algorithms (e.g.
 	// ["RS256", "ES256"]). When empty, a safe set scoped to the configured key
 	// type is used (HMAC for a shared secret, asymmetric for JWKS/RSA keys).
-	Algorithms           []string          `yaml:"algorithms,omitempty" json:"algorithms,omitempty"`
-	Secret               string            `yaml:"secret,omitempty" json:"secret"`
-	PublicKey            string            `yaml:"publicKey,omitempty" json:"publicKey"`
-	Issuer               string            `yaml:"issuer,omitempty" json:"issuer"`
-	Audience             string            `yaml:"audience,omitempty" json:"audience"`
-	JwksUrl              string            `yaml:"jwksUrl,omitempty" json:"jwksUrl"`
-	JwksFile             string            `yaml:"jwksFile,omitempty" json:"jwksFile"`
-	ForwardAuthorization bool              `yaml:"forwardAuthorization,omitempty" json:"forwardAuthorization"`
-	ClaimsExpression     string            `yaml:"claimsExpression,omitempty" json:"claimsExpression"`
-	ForwardHeaders       map[string]string `yaml:"forwardHeaders,omitempty" json:"forwardHeaders"`
+	Algorithms           []string `yaml:"algorithms,omitempty" json:"algorithms,omitempty"`
+	Secret               string   `yaml:"secret,omitempty" json:"secret"`
+	PublicKey            string   `yaml:"publicKey,omitempty" json:"publicKey"`
+	Issuer               string   `yaml:"issuer,omitempty" json:"issuer"`
+	Audience             string   `yaml:"audience,omitempty" json:"audience"`
+	JwksUrl              string   `yaml:"jwksUrl,omitempty" json:"jwksUrl"`
+	JwksFile             string   `yaml:"jwksFile,omitempty" json:"jwksFile"`
+	ForwardAuthorization bool     `yaml:"forwardAuthorization,omitempty" json:"forwardAuthorization"`
+	ClaimsExpression     string   `yaml:"claimsExpression,omitempty" json:"claimsExpression"`
+	// ForwardHeaders maps upstream headers to claim paths.
+	// Deprecated: use Forward.Headers instead.
+	ForwardHeaders map[string]string `yaml:"forwardHeaders,omitempty" json:"forwardHeaders"`
+	// Forward projects verified claims onto the upstream request as headers,
+	// query parameters and cookies.
+	Forward *ForwardClaimsRule `yaml:"forward,omitempty" json:"forward,omitempty"`
+}
+
+// ForwardClaimsRule configures how a verified user's claims are projected onto
+// the upstream request. Values are claim paths with dot notation for nested
+// objects ("resource_access.app.tenant"), or templates interpolating several
+// of them ("{{ .given_name }} {{ .family_name }}").
+type ForwardClaimsRule struct {
+	// Headers, Query and Cookies map a destination key to a claim path.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	Query   map[string]string `yaml:"query,omitempty" json:"query,omitempty"`
+	Cookies map[string]string `yaml:"cookies,omitempty" json:"cookies,omitempty"`
+
+	// StripInbound removes any client-supplied copy of the mapped keys before
+	// projecting. Enabled unless explicitly set to false, which is only safe
+	// when nothing but the gateway can reach the upstream.
+	StripInbound *bool `yaml:"stripInbound,omitempty" json:"stripInbound,omitempty"`
+
+	// ArraySeparator joins array claims such as "groups". Defaults to ",".
+	ArraySeparator string `yaml:"arraySeparator,omitempty" json:"arraySeparator,omitempty"`
+
+	// Encoding is "auto" (default), which base64-encodes non-ASCII values and
+	// flags them with a "<Header>-Encoding: base64" companion header, or "raw".
+	Encoding string `yaml:"encoding,omitempty" json:"encoding,omitempty"`
+
+	// MaxValueBytes bounds a single projected value. Defaults to 4096.
+	MaxValueBytes int `yaml:"maxValueBytes,omitempty" json:"maxValueBytes,omitempty"`
+
+	// AccessTokenHeader and IDTokenHeader forward the raw tokens to the upstream
+	// when set, e.g. "Authorization" or "X-Auth-Id-Token".
+	AccessTokenHeader string `yaml:"accessTokenHeader,omitempty" json:"accessTokenHeader,omitempty"`
+	IDTokenHeader     string `yaml:"idTokenHeader,omitempty" json:"idTokenHeader,omitempty"`
 }
 type OauthRulerMiddleware struct {
 	// ClientID is the application's ID.
@@ -182,6 +218,19 @@ type OauthRulerMiddleware struct {
 	Scopes []string `yaml:"scopes" json:"scopes"`
 	// contains filtered or unexported fields
 	State string `yaml:"state" json:"state"`
+
+	// Issuer, when set, is enforced on JWT tokens issued by the provider.
+	Issuer string `yaml:"issuer,omitempty" json:"issuer,omitempty"`
+	// Audience, when set, is enforced on JWT access tokens. The ID token's
+	// audience is always checked against clientId, as OIDC requires.
+	Audience string `yaml:"audience,omitempty" json:"audience,omitempty"`
+
+	// ClaimsSource lists where user claims are read from, in increasing order of
+	// precedence: id_token, userinfo, access_token.
+	ClaimsSource []string `yaml:"claimsSource,omitempty" json:"claimsSource,omitempty"`
+
+	// Forward projects the authenticated user's claims onto the upstream request.
+	Forward *ForwardClaimsRule `yaml:"forward,omitempty" json:"forward,omitempty"`
 }
 type OauthEndpoint struct {
 	AuthURL     string `yaml:"authUrl" json:"authUrl"`


### PR DESCRIPTION
Add a shared ClaimMapper, used by both the JWT and OAuth middlewares, that
projects verified claims onto the upstream request as headers, query parameters
and cookies